### PR TITLE
In the get_bind method of_SignallingSession, mapper parameter may be None e.g query.values(*column).

### DIFF
--- a/flaskext/sqlalchemy.py
+++ b/flaskext/sqlalchemy.py
@@ -190,7 +190,7 @@ class _SignallingSession(Session):
         self._model_changes = {}
 
     def get_bind(self, mapper, clause=None):
-        bind_key = mapper.mapped_table.info.get('bind_key')
+        bind_key = mapper and mapper.mapped_table.info.get('bind_key') or None
         if bind_key is not None:
             state = get_state(self.app)
             return state.db.get_engine(self.app)


### PR DESCRIPTION
In the get_bind method of_SignallingSession, mapper parameter may be None e.g query.values(*column).
We should handle it otherwise AttributeError will be raised
