### PR TITLE
Some fixes about multiple databases of Flask-SQLAlchemy.

### DIFF
--- a/flaskext/sqlalchemy.py
+++ b/flaskext/sqlalchemy.py
@@ -412,6 +412,7 @@ class _EngineConnector(object):
         assert self._bind in binds, \
             'Bind %r is not specified.  Set it in the SQLALCHEMY_BINDS ' \
             'configuration variable' % self._bind
+        return binds[self._bind]
 
     def get_engine(self):
         with self._lock:
@@ -714,7 +715,7 @@ class SQLAlchemy(object):
             state = get_state(app)
             connector = state.connectors.get(bind)
             if connector is None:
-                connector = self.make_connector(app)
+                connector = self.make_connector(app, bind)
                 state.connectors[bind] = connector
             return connector.get_engine()
 


### PR DESCRIPTION
Before, all my models with **bind_key** got the engine of default bind (SQLALCHEMY_DATABASE_URI).　Multiple databases did not work.

Make get_engine of SQLAlchemy and _EngineConnector classes to work, and then multiple databases with binds can work in Flask-SQLAlchemy.
