### PR TITLE
Slight change to DB URI in Quickstart

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -25,7 +25,7 @@ used to declare models::
     from flaskext.sqlalchemy import SQLAlchemy
 
     app = Flask(__name__)
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:////tmp/test.db'
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///'+'/tmp/test.db'
     db = SQLAlchemy(app)
 
 


### PR DESCRIPTION
I made a change to the DB URI to make it more obvious what the different parts are. This may help clear up confusion about how many /'s need to be use on Windows.
