### PR TITLE
Preserve info['bind_key'] when creating table

### DIFF
--- a/flaskext/sqlalchemy.py
+++ b/flaskext/sqlalchemy.py
@@ -52,6 +52,7 @@ def _make_table(db):
             args = (args[0], db.metadata) + args[1:]
         info = kwargs.pop('info', None) or {}
         info.setdefault('bind_key', None)
+        kwargs['info'] = info
         return sqlalchemy.Table(*args, **kwargs)
     return _make_table
 


### PR DESCRIPTION
When creating a table on in the non-declarative way, info/bind_key was lost. This resulted either in the table being created in the default database or in an error.
