### PR TITLE
Let the user pass keyword arguments to the 'create_engine'

### DIFF
--- a/flaskext/sqlalchemy.py
+++ b/flaskext/sqlalchemy.py
@@ -593,10 +593,13 @@ class SQLAlchemy(object):
     """
 
     def __init__(self, app=None, use_native_unicode=True,
-                 session_extensions=None, session_options=None):
+                 session_extensions=None, session_options=None,
+                 engine_options=None):
         self.use_native_unicode = use_native_unicode
         self.session_extensions = to_list(session_extensions, []) + \
                                   [_SignallingSessionExtension()]
+
+        self.engine_options = engine_options
 
         if session_options is None:
             session_options = {}
@@ -722,6 +725,9 @@ class SQLAlchemy(object):
             unu = self.use_native_unicode
         if not unu:
             options['use_native_unicode'] = False
+
+        if self.engine_options:
+            options.update(self.engine_options)
 
     @property
     def engine(self):

--- a/test_sqlalchemy.py
+++ b/test_sqlalchemy.py
@@ -79,6 +79,16 @@ class BasicAppTestCase(unittest.TestCase):
     def test_helper_api(self):
         self.assertEqual(self.db.metadata, self.db.Model.metadata)
 
+    def test_engine_options_echo(self):
+        app = flask.Flask(__name__)
+        db = sqlalchemy.SQLAlchemy(app, engine_options={'echo': True})
+        self.assertEqual(True, db.engine.echo)
+
+    def test_engine_options_no_echo(self):
+        app = flask.Flask(__name__)
+        db = sqlalchemy.SQLAlchemy(app, engine_options={'echo': False})
+        self.assertEqual(False, db.engine.echo)
+
 
 class TestQueryProperty(unittest.TestCase):
 


### PR DESCRIPTION
This parameter allows the user to pass keyword options for the
'create_engine' function, which is not currently possible(eg: Adding a
PoolListener).
