### PR TITLE
Use StaticPool for in-memory sqlite databases

### DIFF
--- a/flask_sqlalchemy.py
+++ b/flask_sqlalchemy.py
@@ -26,6 +26,7 @@ from sqlalchemy.orm.exc import UnmappedClassError
 from sqlalchemy.orm.session import Session
 from sqlalchemy.orm.interfaces import MapperExtension, SessionExtension, \
      EXT_CONTINUE
+from sqlalchemy.pool import NullPool, StaticPool
 from sqlalchemy.interfaces import ConnectionProxy
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.ext.declarative import declarative_base, DeclarativeMeta
@@ -708,25 +709,22 @@ class SQLAlchemy(object):
             options.setdefault('pool_size', 10)
             options.setdefault('pool_recycle', 7200)
         elif info.drivername == 'sqlite':
-            pool_size = options.get('pool_size')
-            detected_in_memory = False
-            # we go to memory and the pool size was explicitly set to 0
-            # which is fail.  Let the user know that
             if info.database in (None, '', ':memory:'):
-                detected_in_memory = True
-                if pool_size == 0:
-                    raise RuntimeError('SQLite in memory database with an '
-                                       'empty queue not possible due to data '
-                                       'loss.')
-            # if pool size is None or explicitly set to 0 we assume the
-            # user did not want a queue for this sqlite connection and
-            # hook in the null pool.
-            elif not pool_size:
-                from sqlalchemy.pool import NullPool
-                options['poolclass'] = NullPool
+                # We cannot do connection pooling for in-memory databases.
+                # The StaticPool implementation will maintain a single
+                # connection globally.
+                options['poolclass'] = StaticPool
+                options['connect_args'] = {'check_same_thread': False}
+                del options['pool_size']
+            else:
+                # if pool size is None or explicitly set to 0 we assume the
+                # user did not want a queue for this sqlite connection and
+                # hook in the null pool.
+                pool_size = options.get('pool_size')
+                if not pool_size:
+                    options['poolclass'] = NullPool
 
-            # if it's not an in memory database we make the path absolute.
-            if not detected_in_memory:
+                # if it's not an in memory database we make the path absolute.
                 info.database = os.path.join(app.root_path, info.database)
 
         unu = app.config['SQLALCHEMY_NATIVE_UNICODE']


### PR DESCRIPTION
http://www.sqlite.org/inmemorydb.html

"When a connection opened to ':memory:', no disk file is opened. Instead, a new database is created purely in memory. The database ceases to exist as soon as the database connection is closed. Every :memory: database is distinct from every other. So, opening two database connections each with the filename ":memory:" will create two independent in-memory databases."

http://docs.sqlalchemy.org/en/rel_0_7/dialects/sqlite.html#using-a-memory-database-in-multiple-threads

"To use a :memory: database in a multithreaded scenario, the same connection object must be shared among threads, since the database exists only within the scope of that connection. The StaticPool implementation will maintain a single connection globally, and the check_same_thread flag can be passed to Pysqlite as False."
