### PR TITLE
Removed 'setuptools' from install_requires to fix "pip install -t <some_target>" installations

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -71,7 +71,7 @@ Accessing the data in database is easy as a pie:
 Simple Relationships
 --------------------
 
-SQLAlchemy collects to relational databases and what relational databases
+SQLAlchemy connects to relational databases and what relational databases
 are really good at are relations.  As such, we shall have an example of an
 application that uses two tables that have a relationship to each other::
 

--- a/flask_sqlalchemy.py
+++ b/flask_sqlalchemy.py
@@ -167,6 +167,11 @@ class _SignalTrackingMapperExtension(MapperExtension):
 
     def _record(self, mapper, model, operation):
         pk = tuple(mapper.primary_key_from_instance(model))
+        # FIXME: Some hack just to prevent from crashing when trying to look
+        # for _model_changes attribute. Happens when loading fixutres with
+        # the fixture library.
+        if not hasattr(orm.object_session(model), '_model_changes'):
+            orm.object_session(model)._model_changes = dict()
         orm.object_session(model)._model_changes[pk] = (model, operation)
         return EXT_CONTINUE
 


### PR DESCRIPTION
I use "pip install -t packages -r requirements.txt" to install all the project's requirements into a subdirectory of the project for Google App Engine since it doesn't support adding anything to site-packages.  I then have a script at startup to add this packages directory to the sys.path.

"pip install -t" appears to uninstall distribute (from flask-sqlalchemy's setuptools requirement) and then install it in the packages folder, which breaks future installations in requirements.txt (I get an error about unable to import setuptools).

Removing the requirement from flask-sqlalchemy\setup.py fixes the install of my requirements.txt.  I checked the blame, and 'setuptools' was added 2010-06-05 to silence a warning when using zc.buildout.  I think fixing pip install -t is better than having a warning (I checked all the other requirements for my project, and no others include setuptools).  https://github.com/mitsuhiko/flask-sqlalchemy/commit/dbb7163bfafc73ca020487c73f17b646a710227e
