### PR TITLE
Bind support and query debug fix

### DIFF
--- a/flask_sqlalchemy.py
+++ b/flask_sqlalchemy.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for more details.
 """
 from __future__ import with_statement, absolute_import
+from distutils.version import StrictVersion
 import os
 import re
 import sys
@@ -133,6 +134,19 @@ def _calling_context(app_path):
     return '<unknown>'
 
 
+def _add_debug_query(statement, parameters, start, app_package, bind):
+    """Remember query debug information"""
+    ctx = connection_stack.top
+    if ctx is not None:
+        queries = getattr(ctx, 'sqlalchemy_queries', None)
+        if queries is None:
+            queries = []
+            setattr(ctx, 'sqlalchemy_queries', queries)
+        queries.append(_DebugQueryTuple((
+            statement, parameters, start, _timer(),
+            _calling_context(app_package), bind)))
+
+
 class _ConnectionDebugProxy(ConnectionProxy):
     """Helps debugging the database."""
 
@@ -146,15 +160,44 @@ class _ConnectionDebugProxy(ConnectionProxy):
         try:
             return execute(cursor, statement, parameters, context)
         finally:
-            ctx = connection_stack.top
-            if ctx is not None:
-                queries = getattr(ctx, 'sqlalchemy_queries', None)
-                if queries is None:
-                    queries = []
-                    setattr(ctx, 'sqlalchemy_queries', queries)
-                queries.append(_DebugQueryTuple((
-                    statement, parameters, start, _timer(),
-                    _calling_context(self.app_package), self.bind)))
+            _add_debug_query(statement, parameters, start,
+                self.app_package, self.bind)
+
+
+class _QueryDebugger(ConnectionProxy):
+    """Helps debugging the database."""
+
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        """Use singleton to make sure that handlers are attached only once"""
+        if not cls._instance:
+            cls._instance = super(_QueryDebugger, cls).__new__(
+                cls, *args, **kwargs)
+
+            from sqlalchemy import event
+            from sqlalchemy.engine import Engine
+
+            @event.listens_for(Engine, "before_cursor_execute")
+            def before_cursor_execute(conn, cursor, statement,
+                                      parameters, context, executemany):
+                context._query_start_time = _timer()
+
+            @event.listens_for(Engine, "after_cursor_execute")
+            def after_cursor_execute(conn, cursor, statement,
+                                     parameters, context, executemany):
+                app_packege = cls._instance.engines[conn.engine]['app_package']
+                bind = cls._instance.engines[conn.engine]['bind']
+                _add_debug_query(statement, parameters,
+                    context._query_start_time, app_packege, bind)
+
+        return cls._instance
+
+    engines = {}
+
+    def __init__(self, engine, import_name, bind):
+        """Remember import name and bind for an engine"""
+        self.engines[engine] = {'app_package': import_name, 'bind': bind}
 
 
 class _SignalTrackingMapperExtension(MapperExtension):
@@ -439,13 +482,19 @@ class _EngineConnector(object):
             options = {'convert_unicode': True}
             self._sa.apply_pool_defaults(self._app, options)
             self._sa.apply_driver_hacks(self._app, info, options)
-            if _record_queries(self._app):
+            if (_record_queries(self._app) and
+                    StrictVersion(sqlalchemy.__version__) <
+                        StrictVersion('0.7.0')):
                 options['proxy'] = _ConnectionDebugProxy(self._app.import_name,
                     self._bind)
             if echo:
                 options['echo'] = True
             self._engine = rv = sqlalchemy.create_engine(info, **options)
             self._connected_for = (uri, echo)
+            if (_record_queries(self._app) and
+                    StrictVersion(sqlalchemy.__version__) >=
+                        StrictVersion('0.7.0')):
+                _QueryDebugger(rv, self._app.import_name, self._bind)
             return rv
 
 


### PR DESCRIPTION
1) get_debug_queries does not provide enough information for the query executing in a setup with multiple binds available.
This fix makes bind information available for debugging.
2) Query debugging is not compatible with sqlalchemy >= 7.0.
The fix adds proper way of debugging queries though new api.
