### PR TITLE
Fix apply_driver_hacks for various mysql drivers, rather than just the default driver.

### DIFF
--- a/flask_sqlalchemy.py
+++ b/flask_sqlalchemy.py
@@ -703,7 +703,7 @@ class SQLAlchemy(object):
         like pool sizes for MySQL and sqlite.  Also it injects the setting of
         `SQLALCHEMY_NATIVE_UNICODE`.
         """
-        if info.drivername == 'mysql':
+        if info.drivername.startswith('mysql'):
             info.query.setdefault('charset', 'utf8')
             options.setdefault('pool_size', 10)
             options.setdefault('pool_recycle', 7200)


### PR DESCRIPTION
Currently the fix for #2 only considers the default mysql driver. This means none of the hacks get applied if you're using other drivers, e.g., [oursql](http://packages.python.org/oursql/). This pull request will ensure hacks are applied to all mysql drivers, therefore fixing #48.
