### PR TITLE
Record operations only for signalling sessions

### DIFF
--- a/flask_sqlalchemy.py
+++ b/flask_sqlalchemy.py
@@ -166,8 +166,12 @@ class _SignalTrackingMapperExtension(MapperExtension):
         return self._record(mapper, instance, 'update')
 
     def _record(self, mapper, model, operation):
-        pk = tuple(mapper.primary_key_from_instance(model))
-        orm.object_session(model)._model_changes[pk] = (model, operation)
+        s = orm.object_session(model)
+        # Skip the operation tracking when a non signalling session
+        # is used.
+        if isinstance(s, _SignallingSessionExtension):
+            pk = tuple(mapper.primary_key_from_instance(model))
+            s._model_changes[pk] = (model, operation)
         return EXT_CONTINUE
 
 


### PR DESCRIPTION
In some scenarios, model classes derived from `SQLAlchemy(...).Model` may be used with basic SQLAlchemy session instances which aren't extended with signalling functionality.

Before this fix, when you try using a vanilla session with such models, you would get exception like this:

```
  File ".../flask_sqlalchemy.py", line 163, in after_insert
    return self._record(mapper, instance, 'insert')
  File ".../flask_sqlalchemy.py", line 172, in _record
    s._model_changes[pk] = (model, operation)
AttributeError: 'SessionMaker' object has no attribute '_model_changes'
```

Here are couple of scenarios where this bug manifests itself:
1. When writing tests that use test-fixture-provided session
2. When using model classes outside a flask application

With this fix, this problem is resolved.

Note: this pull request solves the same problem as #89, but in a less intrusive way since it avoids contaminating non-signalling-session objects with extra unwanted state: _mode_changes.
