### PR TITLE
flask.ext.sqlalchemy

### DIFF
--- a/examples/hello.py
+++ b/examples/hello.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from flask import Flask, request, flash, url_for, redirect, \
      render_template, abort
-from flaskext.sqlalchemy import SQLAlchemy
+from flask.ext.sqlalchemy import SQLAlchemy
 
 
 app = Flask(__name__)


### PR DESCRIPTION
On windows 7, python2.6 can not find flaskext module, however as suggested here[1]
flask.ext.sqlalchemy worked for me.

1.http://stackoverflow.com/questions/10572498/importerror-no-module-named-sqlalchemy
