### PR TITLE
add "bind" option to signallingsession

### DIFF
--- a/flask_sqlalchemy.py
+++ b/flask_sqlalchemy.py
@@ -196,13 +196,10 @@ class _SignallingSession(Session):
     def __init__(self, db, autocommit=False, autoflush=False, **options):
         self.app = db.get_app()
         self._model_changes = {}
-        try:
-            e = options.pop('bind')
-        except:
-            e = db.engine
+        bind = options.pop('bind', db.engine)
         Session.__init__(self, autocommit=autocommit, autoflush=autoflush,
                          extension=db.session_extensions,
-                         bind=e,
+                         bind=bind,
                          binds=db.get_binds(self.app), **options)
 
     def get_bind(self, mapper, clause=None):


### PR DESCRIPTION
create_scoped_session can now accept a "bind" option (supplied through the "options" dict). This way you can create flask-sqlalchemy scoped sessions (with all the teardown machinery) for arbitrary binds. Useful because scoped sessions are not created for all binds by default (when you have multiple DBs configured).
