### PR TITLE
Fix ZeroDivisionError when counting Pagination object pages

### DIFF
--- a/flask_sqlalchemy.py
+++ b/flask_sqlalchemy.py
@@ -275,7 +275,11 @@ class Pagination(object):
     @property
     def pages(self):
         """The total number of pages"""
-        return int(ceil(self.total / float(self.per_page)))
+        if self.per_page == 0:
+            pages = 0
+        else:
+            pages = int(ceil(self.total / float(self.per_page)))
+        return pages
 
     def prev(self, error_out=False):
         """Returns a :class:`Pagination` object for the previous page."""

--- a/test_sqlalchemy.py
+++ b/test_sqlalchemy.py
@@ -189,6 +189,10 @@ class PaginationTestCase(unittest.TestCase):
         self.assertEqual(list(p.iter_pages()),
                          [1, 2, None, 8, 9, 10, 11, 12, 13, 14, None, 24, 25])
 
+    def test_pagination_pages_when_0_items_per_page(self):
+        p = sqlalchemy.Pagination(None, 1, 0, 500, [])
+        self.assertEqual(p.pages, 0)
+
 
 class BindsTestCase(unittest.TestCase):
 


### PR DESCRIPTION
When `per_page` was set to `0`, there was `ZeroDivisionError` raised in `Pagination.pages` property.
