### PR TITLE
add master/slave automatic selection when readonly sql

### DIFF
--- a/flask_sqlalchemy.py
+++ b/flask_sqlalchemy.py
@@ -170,6 +170,14 @@ class _SignallingSession(Session):
             if bind_key is not None:
                 state = get_state(self.app)
                 return state.db.get_engine(self.app, bind=bind_key)
+        # if reayonly use the slave engine 
+        # see http://docs.sqlalchemy.org/en/rel_0_8/orm/session.html#custom-vertical-partitioning
+        if not self._flushing:
+            state = get_state(self.app)
+            try:
+                return state.db.get_engine(self.app, bind='slave')
+            except Exception, e:
+                pass
         return Session.get_bind(self, mapper, clause)
 
 


### PR DESCRIPTION
I have two database engine . one is readonly.
use the one  when the sql is like "select ..."  or  "show ..."

``` python
SQLALCHEMY_DATABASE_URI = 'mysql://%s:%s@%s:%s/%s' % (_DBUSER, _DBPASS,
_DBHOST, _DBPORT, _DBNAME)

SQLALCHEMY_BINDS = {
'slave':  'mysql://%s:%s@%s:%s/%s' % (_DBUSER, _DBPASS, _DBHOST_S,
_DBPORT, _DBNAME)
}
```
# 

This is not use in _bind_key  way.

may be we count defind something like this:

``` python
SQLALCHEMY_DATABASE_URI = 'mysql://%s:%s@%s:%s/%s' % (_DBUSER, _DBPASS,
_DBHOST, _DBPORT, _DBNAME)
SQLALCHEMY_DATABASE_URI_SLAVE = 'mysql://%s:%s@%s:%s/%s' % (_DBUSER, _DBPASS, _DBHOST_S,
_DBPORT, _DBNAME

SQLALCHEMY_BINDS = {'eg1':'...','eg2':'...'}
SQLALCHEMY_BINDS_SLAVE = {'eg1':'...','eg2':'...'}
```
