### PR TITLE
Record operations only for signalling sessions (reprise)

### DIFF
--- a/flask_sqlalchemy.py
+++ b/flask_sqlalchemy.py
@@ -219,8 +219,11 @@ class _MapperSignalEvents(object):
 
     @staticmethod
     def _record(mapper, target, operation):
-        pk = tuple(mapper.primary_key_from_instance(target))
-        orm.object_session(target)._model_changes[pk] = (target, operation)
+        s = orm.object_session(target)
+        if isinstance(s, _SignallingSession):
+            pk = tuple(mapper.primary_key_from_instance(target))
+            s._model_changes[pk] = (target, operation)
+
 
 def get_debug_queries():
     """In debug mode Flask-SQLAlchemy will log all the SQL queries sent

--- a/test_sqlalchemy.py
+++ b/test_sqlalchemy.py
@@ -6,6 +6,7 @@ import unittest
 from datetime import datetime
 import flask
 from flask.ext import sqlalchemy
+from sqlalchemy.orm import sessionmaker
 
 
 def make_todo_model(db):
@@ -454,6 +455,39 @@ class CommitOnTeardownTestCase(unittest.TestCase):
         self.assertEqual(self.client.get('/').data, '')
 
 
+class StandardSessionTestCase(unittest.TestCase):
+    def test_insert_update_delete(self):
+        # Ensure _SignalTrackingMapperExtension doesn't croak when
+        # faced with a vanilla SQLAlchemy session.
+        #
+        # Verifies that "AttributeError: 'SessionMaker' object has no attribute '_model_changes'"
+        # is not thrown.
+        app = flask.Flask(__name__)
+        app.config['SQLALCHEMY_ENGINE'] = 'sqlite://'
+        app.config['TESTING'] = True
+        db = sqlalchemy.SQLAlchemy(app)
+        Session = sessionmaker(bind=db.engine)
+
+        class QazWsx(db.Model):
+            id = db.Column(db.Integer, primary_key=True)
+            x = db.Column(db.String, default='')
+
+        db.create_all()
+        session = Session()
+        session.add(QazWsx())
+        session.flush() # issues an INSERT.
+        session.expunge_all()
+        qaz_wsx = session.query(QazWsx).first()
+        assert qaz_wsx.x == ''
+        qaz_wsx.x = 'test'
+        session.flush() # issues an UPDATE.
+        session.expunge_all()
+        qaz_wsx = session.query(QazWsx).first()
+        assert qaz_wsx.x == 'test'
+        session.delete(qaz_wsx) # issues a DELETE.
+        assert session.query(QazWsx).first() is None
+
+
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(BasicAppTestCase))
@@ -468,6 +502,7 @@ def suite():
     suite.addTest(unittest.makeSuite(CommitOnTeardownTestCase))
     if flask.signals_available:
         suite.addTest(unittest.makeSuite(SignallingTestCase))
+    suite.addTest(unittest.makeSuite(StandardSessionTestCase))
     return suite
 
 


### PR DESCRIPTION
This is a rebase of #109 on current master. The original changes were (I assume accidentally) undone in #123, causing a regression (but unnoticed since the test case was also removed).

This also fixes #89 (again).
