### PR TITLE
fix before_models_committed to actually fire with stuff

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -179,11 +179,15 @@ class _SessionSignalEvents(object):
 
     @staticmethod
     def session_signal_before_commit(session):
-        if not isinstance(session, SignallingSession):
-            return
-        d = session._model_changes
-        if d:
-            before_models_committed.send(session.app, changes=d.values())
+        if session._new or session._deleted or session.identity_map:
+            s = []
+            for new in session._new:
+                s.append((new.obj(), 'insert'))
+            for delete in session._deleted:
+                s.append((delete.obj(), 'delete'))
+            for mod in session.identity_map._modified:
+                s.append((mod.obj(), 'update'))
+            before_models_committed.send(session.app, changes=s)
 
     @staticmethod
     def session_signal_after_commit(session):


### PR DESCRIPTION
As highlighted by @insom before_models_committed will not fire because it has no changes.

Also see https://github.com/mitsuhiko/flask-sqlalchemy/pull/117
and https://github.com/mitsuhiko/flask-sqlalchemy/pull/95

Its plainly obvious this is broken (even the simplest of test cases shows it) When will any of these fixed be pulled into main???
