### PR TITLE
no need to have the code order_by(None), it will bring some bug. such as...

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -437,7 +437,7 @@ class BaseQuery(orm.Query):
         if page == 1 and len(items) < per_page:
             total = len(items)
         else:
-            total = self.order_by(None).count()
+            total = self.count()
 
         return Pagination(self, page, per_page, total, items)
 


### PR DESCRIPTION
...:

in the latest version flask_sqlalchemy, the exception msg is:

Traceback (most recent call last):
File "/data/release/harem/views/frontend.py", line 248, in show_users_order_by_level
paginate(page_num, current_app.config['ARENA_USER_COUNT_PER_PAGE']*3)
File "/usr/local/lib/python2.7/site-packages/flask_sqlalchemy/**init**.py", line 414, in paginate
total = self.order_by(None).count()
File "", line 1, in
File "/usr/local/lib/python2.7/site-packages/sqlalchemy/orm/query.py", line 50, in generate
assertion(self, fn.func_name)
File "/usr/local/lib/python2.7/site-packages/sqlalchemy/orm/query.py", line 402, in _no_limit_offset
% (meth, meth)
InvalidRequestError: Query.order_by() being called on a Query which already has LIMIT or OFFSET applied. To modify the row-limited results of a Query, call from_self() first. Other
wise, call order_by() before limit() or offset() are applied.

my code is:

pgnt = User.query.limit(current_app.config['ARENA_USER_MAX_COUNT']).\
paginate(page_num, current_app.config['ARENA_USER_COUNT_PER_PAGE'])

but in the old version of flask_sqlalchemy, It works well.
so I compare the two versions, find this code:

if page == 1 and len(items) < per_page:
total = len(items)
else:
total = self.order_by(None).count()

in the old version, there is no such code.
