### PR TITLE
Fix _execute_for_all_tables() in Python 3

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -873,7 +873,7 @@ class SQLAlchemy(object):
 
         if bind == '__all__':
             binds = [None] + list(app.config.get('SQLALCHEMY_BINDS') or ())
-        elif isinstance(bind, basestring) or bind is None:
+        elif isinstance(bind, string_types) or bind is None:
             binds = [bind]
         else:
             binds = bind


### PR DESCRIPTION
- SQLAlchemy._execute_for_all_tables()
  Command could not be executed against specific binds, because
  types of strings were checked against basestring().
  
  Use string_types from the compatibility layer, instead to support
  Python 3.
