### PR TITLE
Update trove classifier: Python 3 as supported languages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,8 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.3',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]


### PR DESCRIPTION
Tools like https://github.com/brettcannon/caniusepython3 depend on trove classifier specified to determine if a package supports Python 3. 
