### PR TITLE
Python 3 Error When Using Binds

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -873,7 +873,7 @@ class SQLAlchemy(object):
 
         if bind == '__all__':
             binds = [None] + list(app.config.get('SQLALCHEMY_BINDS') or ())
-        elif isinstance(bind, basestring) or bind is None:
+        elif isinstance(bind, string_types) or bind is None:
             binds = [bind]
         else:
             binds = bind


### PR DESCRIPTION
Was trying to use binds on a project of mine and which seems to have run across some code which was still using `basestring`.  I've swapped it out with `_compact.string_types` and it seems to fix the issue.
