### PR TITLE
Fix typo: 'where' -> 'were'.

### DIFF
--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -10,7 +10,7 @@ The following two signals exist:
 
 .. data:: models_committed
 
-   This signal is sent when changed models where committed to the
+   This signal is sent when changed models were committed to the
    database.  The sender is the application that emitted the changes
    and the models and an operation identifier are passed as list of tuples
    in the form ``(model, operation)`` to the receiver in the `changes`


### PR DESCRIPTION
Just a simple typo fix in the signals doc.
