### PR TITLE
Support generating tablenames in more cases.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -46,3 +46,4 @@ Patches and Suggestions
 - Daniel Lepage
 - Ignacy Sokołowski
 - Steven Harms
+- David Lord @davidism

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,14 @@ Changelog
 Here you can see the full list of changes between each Flask-SQLAlchemy
 release.
 
+Version 2.1
+-----------
+
+In development
+
+- Table names are automatically generated in more cases, including
+  subclassing mixins and abstract models.
+
 Version 2.0
 -----------
 


### PR DESCRIPTION
Extends naming rules to apply to base classes of models.  This supports joined table and single table inheritance, inheriting from mixins and abstract models, and _some_ complex inheritance combinations.

Resolves the following issues:
- mitsuhiko/flask-sqlalchemy#83
- mitsuhiko/flask-sqlalchemy#198
- mitsuhiko/flask-sqlalchemy#204

I am almost 100% confident that this does not break existing behavior; however, the original behavior was not well documented or tested.  This does seem to cover all "normal" cases that I've run into, and I've added tests for these cases.  I did not test concrete table inheritance in its various forms as I am not familiar enough with it.
