### PR TITLE
Have the SQLALCHEMY_RECORD_QUERIES setting take precedence over DEBUG

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -28,9 +28,11 @@ A list of configuration keys currently understood by the extension:
                                    be useful for debugging.
 ``SQLALCHEMY_RECORD_QUERIES``      Can be used to explicitly disable or
                                    enable query recording.  Query recording
-                                   automatically happens in debug or testing
-                                   mode.  See :func:`get_debug_queries` for
-                                   more information.
+                                   is turned on by default in debug or
+                                   testing mode, but that behavior can be
+                                   overridden using this option.  See
+                                   :func:`get_debug_queries` for more
+                                   information.
 ``SQLALCHEMY_NATIVE_UNICODE``      Can be used to explicitly disable native
                                    unicode support.  This is required for
                                    some database adapters (like PostgreSQL

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -498,11 +498,11 @@ class _QueryProperty(object):
 
 
 def _record_queries(app):
-    if app.debug:
-        return True
     rq = app.config['SQLALCHEMY_RECORD_QUERIES']
     if rq is not None:
         return rq
+    if app.debug:
+        return True
     return bool(app.config.get('TESTING'))
 
 


### PR DESCRIPTION
This allows query recording to be disabled regardless of the other application settings
