### PR TITLE
Add support for nested sessions (SAVEPOINTs) in modifications tracking

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -48,3 +48,4 @@ Patches and Suggestions
 - Steven Harms
 - David Lord @davidism
 - Alec Nikolas Reiter @justanr
+- Barak Alon

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -22,7 +22,7 @@ from flask import _request_ctx_stack, abort, has_request_context, request
 from flask.signals import Namespace
 from operator import itemgetter
 from threading import Lock
-from sqlalchemy import orm, event, inspect
+from sqlalchemy import orm, event
 from sqlalchemy.orm.exc import UnmappedClassError
 from sqlalchemy.orm.session import Session as SessionBase
 from sqlalchemy.engine.url import make_url
@@ -178,67 +178,86 @@ class _SessionSignalEvents(object):
     @classmethod
     def register(cls, session):
         if not hasattr(session, '_model_changes'):
-            session._model_changes = {}
+            session._model_changes_stack = [{}]
 
+        event.listen(session, 'after_transaction_create', cls.after_transaction_create)
         event.listen(session, 'before_flush', cls.record_ops)
         event.listen(session, 'before_commit', cls.record_ops)
         event.listen(session, 'before_commit', cls.before_commit)
         event.listen(session, 'after_commit', cls.after_commit)
-        event.listen(session, 'after_rollback', cls.after_rollback)
+        event.listen(session, 'after_soft_rollback', cls.after_rollback)
 
     @classmethod
     def unregister(cls, session):
         if hasattr(session, '_model_changes'):
-            del session._model_changes
+            del session._model_changes_stack
 
+        event.remove(session, 'after_transaction_create', cls.after_transaction_create)
         event.remove(session, 'before_flush', cls.record_ops)
         event.remove(session, 'before_commit', cls.record_ops)
         event.remove(session, 'before_commit', cls.before_commit)
         event.remove(session, 'after_commit', cls.after_commit)
-        event.remove(session, 'after_rollback', cls.after_rollback)
+        event.remove(session, 'after_soft_rollback', cls.after_rollback)
+
+    @staticmethod
+    def after_transaction_create(session, transaction):
+        try:
+            stack = session._model_changes_stack
+        except AttributeError:
+            return
+
+        if transaction.nested:
+            stack.append({})
 
     @staticmethod
     def record_ops(session, flush_context=None, instances=None):
         try:
-            d = session._model_changes
+            stack = session._model_changes_stack
         except AttributeError:
             return
 
         for targets, operation in ((session.new, 'insert'), (session.dirty, 'update'), (session.deleted, 'delete')):
             for target in targets:
-                state = inspect(target)
-                key = state.identity_key if state.has_identity else id(target)
-                d[key] = (target, operation)
+                key = id(target)
+                stack[-1][key] = (target, operation)
 
     @staticmethod
     def before_commit(session):
         try:
-            d = session._model_changes
+            stack = session._model_changes_stack
         except AttributeError:
             return
 
-        if d:
-            before_models_committed.send(session.app, changes=list(d.values()))
+        if not session.transaction.nested and stack[0]:
+            before_models_committed.send(session.app, changes=list(stack[0].values()))
 
     @staticmethod
     def after_commit(session):
         try:
-            d = session._model_changes
+            stack = session._model_changes_stack
         except AttributeError:
             return
 
-        if d:
-            models_committed.send(session.app, changes=list(d.values()))
-            d.clear()
+        if not session.transaction.nested and stack[0]:
+            models_committed.send(session.app, changes=list(stack[0].values()))
+            stack[0].clear()
+        elif session.transaction.nested:
+            nested_changes = stack.pop()
+            for key, value in nested_changes.items():
+                # Don't overwrite keys that are lower in the stack
+                stack[-1].setdefault(key, value)
 
     @staticmethod
-    def after_rollback(session):
+    def after_rollback(session, previous_transaction):
         try:
-            d = session._model_changes
+            stack = session._model_changes_stack
         except AttributeError:
             return
 
-        d.clear()
+        if previous_transaction.nested:
+            stack.pop()
+        else:
+            stack[0].clear()
 
 
 class _EngineDebuggingSignalEvents(object):


### PR DESCRIPTION
I love the signals for tracking modifications to models. However, they don't yet support [nested sessions](http://docs.sqlalchemy.org/en/latest/orm/session_transaction.html#using-savepoint).

Here is a proposal for adding support for this. It uses a stack of dictionaries instead of just a dictionary for tracking models that have been inserted/updated/deleted. When a nested session begins, a new dictionary is pushed to the stack. If that nested session is rolled back, the changes that happened during that session are removed. If that nested session is committed, the changes are merged into the next item.

Anywho, let me know what you think! This is my first attempt at a contribution to flask-sqlalchemy, so take it easy on me :grin:
