### PR TITLE
Make paginate more efficient with many pages.

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -390,8 +390,20 @@ class Pagination(object):
               </div>
             {% endmacro %}
         """
+
+        pages = []
+        pages += range(1, min(left_edge + 1, self.pages + 1))
+        pages += range(
+            max(self.page - left_current, left_edge + 1),
+            min(self.page + right_current, self.pages - right_edge)
+        )
+        pages += range(
+            max(self.pages - right_edge, right_edge + 1),
+            self.pages + 1
+        )
+
         last = 0
-        for num in xrange(1, self.pages + 1):
+        for num in pages:
             if num <= left_edge or \
                (num > self.page - left_current - 1 and \
                 num < self.page + right_current) or \

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -392,26 +392,28 @@ class Pagination(object):
         """
 
         pages = []
-        pages += range(1, min(left_edge + 1, self.pages + 1))
         pages += range(
-            max(self.page - left_current, left_edge + 1),
-            min(self.page + right_current, self.pages - right_edge)
+            1,
+            min(left_edge + 1, self.pages + 1)
         )
         pages += range(
-            max(self.pages - right_edge, right_edge + 1),
+            max(self.page - left_current, left_edge + 1),
+            min(self.page + right_current, self.pages + 1 - right_edge)
+        )
+        pages += range(
+            max(
+                self.pages + 1 - right_edge,
+                right_edge + 1
+            ),
             self.pages + 1
         )
 
         last = 0
-        for num in pages:
-            if num <= left_edge or \
-               (num > self.page - left_current - 1 and \
-                num < self.page + right_current) or \
-               num > self.pages - right_edge:
-                if last + 1 != num:
-                    yield None
-                yield num
-                last = num
+        for i in pages:
+            if last + 1 != i:
+                yield None
+            yield i
+            last = i
 
 
 class BaseQuery(orm.Query):

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -404,13 +404,14 @@ class Pagination(object):
             max(self.pages + 1 - right_edge, right_edge + 1),
             self.pages + 1
         )
-
         last = 0
         for i in pages:
             if last + 1 != i:
                 yield None
             yield i
             last = i
+        if pages and i != self.pages:
+            yield None
 
 
 class BaseQuery(orm.Query):

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -401,10 +401,7 @@ class Pagination(object):
             min(self.page + right_current, self.pages + 1 - right_edge)
         )
         pages += range(
-            max(
-                self.pages + 1 - right_edge,
-                right_edge + 1
-            ),
+            max(self.pages + 1 - right_edge, right_edge + 1),
             self.pages + 1
         )
 

--- a/test_sqlalchemy.py
+++ b/test_sqlalchemy.py
@@ -335,6 +335,29 @@ class PaginationTestCase(unittest.TestCase):
         self.assertEqual(list(p.iter_pages()),
                          [1, 2, 3, 4, 5, None, 24, 25])
 
+        p.page = 10
+        self.assertEqual(list(p.iter_pages()),
+                         [1, 2, None, 8, 9, 10, 11, 12, 13, 14, None, 24, 25])
+        self.assertEqual(list(p.iter_pages(right_edge=0)),
+                         [1, 2, None, 8, 9, 10, 11, 12, 13, 14, None])
+        self.assertEqual(list(p.iter_pages(left_edge=0)),
+                         [None, 8, 9, 10, 11, 12, 13, 14, None, 24, 25])
+        self.assertEqual(list(p.iter_pages(left_edge=0, right_edge=0)),
+                         [None, 8, 9, 10, 11, 12, 13, 14, None])
+        self.assertEqual(list(p.iter_pages(left_current=0, right_current=0)),
+                         [1, 2, None, 24, 25])
+        self.assertEqual(list(p.iter_pages(left_current=0, right_current=1)),
+                         [1, 2, None, 10, None, 24, 25])
+        self.assertEqual(list(p.iter_pages(left_current=2, right_current=2)),
+                         [1, 2, None, 8, 9, 10, 11, None, 24, 25])
+        self.assertEqual(list(p.iter_pages(left_current=0)),
+                         [1, 2, None, 10, 11, 12, 13, 14, None, 24, 25])
+        self.assertEqual(list(p.iter_pages(right_current=0)),
+                         [1, 2, None, 8, 9, None, 24, 25])
+        self.assertEqual(list(p.iter_pages(
+            left_edge=0, left_current=0, right_current=0, right_edge=0)),
+                         [])
+
         p.page = 5
         self.assertEqual(list(p.iter_pages()),
                          [1, 2, 3, 4, 5, 6, 7, 8, 9, None, 24, 25])
@@ -342,10 +365,6 @@ class PaginationTestCase(unittest.TestCase):
         p.page = 6
         self.assertEqual(list(p.iter_pages()),
                          [1, 2, None, 4, 5, 6, 7, 8, 9, 10, None, 24, 25])
-
-        p.page = 10
-        self.assertEqual(list(p.iter_pages()),
-                         [1, 2, None, 8, 9, 10, 11, 12, 13, 14, None, 24, 25])
 
         p.page = 18
         self.assertEqual(list(p.iter_pages()),
@@ -378,6 +397,7 @@ class PaginationTestCase(unittest.TestCase):
         p.per_page = 249
         self.assertEqual(list(p.iter_pages()),
                          [1, 2, 3])
+
 
 
 

--- a/test_sqlalchemy.py
+++ b/test_sqlalchemy.py
@@ -399,8 +399,6 @@ class PaginationTestCase(unittest.TestCase):
                          [1, 2, 3])
 
 
-
-
     def test_pagination_pages_when_0_items_per_page(self):
         p = fsa.Pagination(None, 1, 0, 500, [])
         self.assertEqual(p.pages, 0)

--- a/test_sqlalchemy.py
+++ b/test_sqlalchemy.py
@@ -334,9 +334,52 @@ class PaginationTestCase(unittest.TestCase):
         self.assertEqual(p.next_num, 2)
         self.assertEqual(list(p.iter_pages()),
                          [1, 2, 3, 4, 5, None, 24, 25])
+
+        p.page = 5
+        self.assertEqual(list(p.iter_pages()),
+                         [1, 2, 3, 4, 5, 6, 7, 8, 9, None, 24, 25])
+
+        p.page = 6
+        self.assertEqual(list(p.iter_pages()),
+                         [1, 2, None, 4, 5, 6, 7, 8, 9, 10, None, 24, 25])
+
         p.page = 10
         self.assertEqual(list(p.iter_pages()),
                          [1, 2, None, 8, 9, 10, 11, 12, 13, 14, None, 24, 25])
+
+        p.page = 18
+        self.assertEqual(list(p.iter_pages()),
+                         [1, 2, None, 16, 17, 18, 19, 20, 21, 22, None, 24, 25])
+
+        p.page = 22
+        self.assertEqual(list(p.iter_pages()),
+                         [1, 2, None, 20, 21, 22, 23, 24, 25])
+
+        p.page = 23
+        self.assertEqual(list(p.iter_pages()),
+                         [1, 2, None, 21, 22, 23, 24, 25])
+
+        p.page = 24
+        self.assertEqual(list(p.iter_pages()),
+                         [1, 2, None, 22, 23, 24, 25])
+
+        p.page = 25
+        self.assertEqual(list(p.iter_pages()),
+                         [1, 2, None, 23, 24, 25])
+
+        p.per_page = 500
+        self.assertEqual(list(p.iter_pages()),
+                         [1])
+
+        p.per_page = 250
+        self.assertEqual(list(p.iter_pages()),
+                         [1, 2])
+
+        p.per_page = 249
+        self.assertEqual(list(p.iter_pages()),
+                         [1, 2, 3])
+
+
 
     def test_pagination_pages_when_0_items_per_page(self):
         p = fsa.Pagination(None, 1, 0, 500, [])


### PR DESCRIPTION
Current paginate iterates over every single page possible, and discards most of them, for large page sets > 50,000 this can be quite slow and noticeable.

This patch should make paginating on many pages much faster since it won't iterate over every single page possible, it should make it constant time more or less.

Speed for 100,000 pages:

``` ipython
(old)
In [14]: %timeit list(flask_sqlalchemy.Pagination(None, 4, 10, 1000000, []).iter_pages())
10 loops, best of 3: 81.6 ms per loop

(new)
In [11]: %timeit list(flask_sqlalchemy.Pagination(None, 4, 10, 1000000, []).iter_pages())
100000 loops, best of 3: 11 µs per loop

```

Also added a bunch of tests for edge cases.
