### PR TITLE
make calling_context more accurate

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -120,9 +120,11 @@ class _DebugQueryTuple(tuple):
 
 def _calling_context(app_path):
     frm = sys._getframe(1)
+    app_path_root = app_path.split('.')[0]
     while frm.f_back is not None:
         name = frm.f_globals.get('__name__')
-        if name and (name == app_path or name.startswith(app_path + '.')):
+        if name and (
+                name == app_path_root or name.startswith(app_path_root + '.')):
             funcname = frm.f_code.co_name
             return '%s:%s (%s)' % (
                 frm.f_code.co_filename,


### PR DESCRIPTION
As detailed in https://github.com/mgood/flask-debugtoolbar/issues/96, the current logic for generating the calling context often fails unnecessarily. 

Specifically, when a project is structured like the following,
```
project
├── project
│   ├── app.py
│   └── views.py
└── setup.py
```
and the flask application is defined by `app = Flask(__name__)` in `app.py`, the calling context will be "unknown" if the query is issued from somewhere other than `app.py`. This is because now `app_path` is `project.app` but the relevant frame that issues the query might be `project.views`.

The updated logic matches the frame with the top level package of the `app_path`.