### PR TITLE
CLI support

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -780,6 +780,7 @@ class SQLAlchemy(object):
             )
 
         app.config.setdefault('SQLALCHEMY_DATABASE_URI', 'sqlite:///:memory:')
+        app.config.setdefault('SQLALCHEMY_CLI_DB_NAME', 'db')
         app.config.setdefault('SQLALCHEMY_BINDS', None)
         app.config.setdefault('SQLALCHEMY_NATIVE_UNICODE', None)
         app.config.setdefault('SQLALCHEMY_ECHO', False)
@@ -801,6 +802,12 @@ class SQLAlchemy(object):
             ))
 
         app.extensions['sqlalchemy'] = _SQLAlchemyState(self)
+
+        if hasattr(app, 'cli'):
+            from .cli import db
+            cli_name = app.config['SQLALCHEMY_CLI_DB_NAME']
+            if cli_name:
+                app.cli.add_command(db, cli_name)
 
         @app.teardown_appcontext
         def shutdown_session(response_or_exc):

--- a/flask_sqlalchemy/cli.py
+++ b/flask_sqlalchemy/cli.py
@@ -61,17 +61,3 @@ def db_drop(bind):
     """Drops database tables."""
     state.db.drop_all(bind=bind)
     click.secho('Database dropped successfully.', fg='green')
-
-
-@db.command('binds')
-@with_appcontext
-def db_binds():
-    """List database binds."""
-    binds = state.db.get_binds()
-    if not binds:
-        raise click.ClickException('No database tables found.')
-    else:
-        for table, engine in binds.items():
-            click.echo("{table.name} -> {engine.url}".format(
-                table=table, engine=engine
-            ))

--- a/flask_sqlalchemy/cli.py
+++ b/flask_sqlalchemy/cli.py
@@ -46,6 +46,7 @@ def db():
 def db_create(bind):
     """Creates database tables."""
     state.db.create_all(bind=bind)
+    click.secho('Database created successfully.', fg='green')
 
 
 @db.command('drop')
@@ -59,3 +60,18 @@ def db_create(bind):
 def db_drop(bind):
     """Drops database tables."""
     state.db.drop_all(bind=bind)
+    click.secho('Database dropped successfully.', fg='green')
+
+
+@db.command('binds')
+@with_appcontext
+def db_binds():
+    """List database binds."""
+    binds = state.db.get_binds()
+    if not binds:
+        raise click.ClickException('No database tables found.')
+    else:
+        for table, engine in binds.items():
+            click.echo("{table.name} -> {engine.url}".format(
+                table=table, engine=engine
+            ))

--- a/flask_sqlalchemy/cli.py
+++ b/flask_sqlalchemy/cli.py
@@ -47,17 +47,3 @@ def db_create(bind):
     """Creates database tables."""
     state.db.create_all(bind=bind)
     click.secho('Database created successfully.', fg='green')
-
-
-@db.command('drop')
-@click.option('--bind', default='__all__')
-@click.confirmation_option(prompt=(
-    "This will destroy all the data in your database. "
-    "Do you want to continue?"
-))
-@with_appcontext
-@commit
-def db_drop(bind):
-    """Drops database tables."""
-    state.db.drop_all(bind=bind)
-    click.secho('Database dropped successfully.', fg='green')

--- a/flask_sqlalchemy/cli.py
+++ b/flask_sqlalchemy/cli.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+"""
+    flask_sqlalchemy.cli
+    ~~~~~~~~~~~~~~~~~~~~
+
+    Command Line Interface for managing the database.
+
+    :copyright: (c) 2017 by David Baumgold.
+    :license: MIT, see LICENSE for more details.
+"""
+
+from __future__ import absolute_import
+
+from functools import wraps
+
+import click
+from flask import current_app
+from werkzeug.local import LocalProxy
+
+try:
+    from flask.cli import with_appcontext
+except ImportError:
+    from flask_cli import with_appcontext
+
+state = LocalProxy(lambda: current_app.extensions['sqlalchemy'])
+
+
+def commit(fn):
+    """Decorator to commit changes after the command is run."""
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        fn(*args, **kwargs)
+        state.db.session.commit()
+    return wrapper
+
+
+@click.group()
+def db():
+    """Manages the database."""
+
+
+@db.command('create')
+@click.option('--bind', default='__all__')
+@with_appcontext
+@commit
+def db_create(bind):
+    """Creates database tables."""
+    state.db.create_all(bind=bind)
+
+
+@db.command('drop')
+@click.option('--bind', default='__all__')
+@click.confirmation_option(prompt=(
+    "This will destroy all the data in your database. "
+    "Do you want to continue?"
+))
+@with_appcontext
+@commit
+def db_drop(bind):
+    """Drops database tables."""
+    state.db.drop_all(bind=bind)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@ from datetime import datetime
 
 import flask
 import pytest
-from click.testing import CliRunner
 
 import sqlalchemy
 import flask_sqlalchemy as fsa
@@ -48,6 +47,7 @@ def Todo(db):
 
 @pytest.fixture
 def clirunner():
+    from click.testing import CliRunner
     return CliRunner()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,9 @@ from datetime import datetime
 
 import flask
 import pytest
+from click.testing import CliRunner
 
+import sqlalchemy
 import flask_sqlalchemy as fsa
 
 
@@ -12,6 +14,10 @@ def app(request):
     app.testing = True
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['SQLALCHEMY_BINDS'] = {
+        'users': 'mysqldb://localhost/users',
+        'geo':   'postgres://localhost/geo',
+    }
     return app
 
 
@@ -38,3 +44,47 @@ def Todo(db):
     db.create_all()
     yield Todo
     db.drop_all()
+
+
+@pytest.fixture
+def clirunner():
+    return CliRunner()
+
+
+@pytest.fixture
+def script_info(app, db):
+    try:
+        from flask.cli import ScriptInfo
+    except ImportError:
+        from flask_cli import ScriptInfo
+
+    return ScriptInfo(create_app=lambda x: app)
+
+
+@pytest.fixture(autouse=True)
+def mock_engines(mocker):
+    """Mock all SQLAlchemy engines, except SQLite
+    (which requires no dependencies"""
+    real_create_engine = sqlalchemy.create_engine
+    real_EngineDebuggingSignalEvents = fsa._EngineDebuggingSignalEvents
+
+    def mock_create_engine(info, **options):
+        # sqlite has no dependencies, so we won't mock it
+        if info.drivername == 'sqlite':
+            return real_create_engine(info, **options)
+        # every other engine has dependencies, so we'll mock them
+        return mocker.Mock(name="{} engine".format(info.drivername))
+
+    def mock_debugging_signals(engine, import_name):
+        if isinstance(engine, mocker.Mock):
+            return mocker.Mock(name=engine._mock_name + " debugging signals")
+        return real_EngineDebuggingSignalEvents(engine, import_name)
+
+    mocker.patch(
+        'flask_sqlalchemy.sqlalchemy.create_engine',
+        mock_create_engine,
+    )
+    mocker.patch(
+        'flask_sqlalchemy._EngineDebuggingSignalEvents',
+        mock_debugging_signals,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,7 +64,7 @@ def script_info(app, db):
 @pytest.fixture(autouse=True)
 def mock_engines(mocker):
     """Mock all SQLAlchemy engines, except SQLite
-    (which requires no dependencies"""
+    (which requires no dependencies)"""
     real_create_engine = sqlalchemy.create_engine
     real_EngineDebuggingSignalEvents = fsa._EngineDebuggingSignalEvents
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,7 @@ def mock_engines(mocker):
         if info.drivername == 'sqlite':
             return real_create_engine(info, **options)
         # every other engine has dependencies, so we'll mock them
-        return mocker.Mock(name="{} engine".format(info.drivername))
+        return mocker.Mock(name="{info.drivername} engine".format(info=info))
 
     def mock_debugging_signals(engine, import_name):
         if isinstance(engine, mocker.Mock):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,59 @@
+import pytest
+from click.testing import CliRunner
+from flask_sqlalchemy.cli import db_create, db_drop, db_binds
+
+
+def test_cli_create(clirunner, db, script_info, mocker):
+    mock_execute = mocker.patch.object(
+        db,
+        "_execute_for_all_tables",
+    )
+
+    result = clirunner.invoke(db_create, obj=script_info)
+    assert result.exit_code == 0
+    mock_execute.assert_called_once_with(None, '__all__', 'create_all')
+    assert "Database created successfully." in result.output
+
+
+def test_cli_drop(clirunner, db, script_info, mocker):
+    mock_execute = mocker.patch.object(
+        db,
+        "_execute_for_all_tables",
+    )
+
+    result = clirunner.invoke(db_drop, input="y", obj=script_info)
+    assert result.exit_code == 0
+    assert result.output.startswith(
+        "This will destroy all the data in your database. "
+        "Do you want to continue? [y/N]:"
+    )
+    mock_execute.assert_called_once_with(None, '__all__', 'drop_all')
+    assert "Database dropped successfully." in result.output
+
+
+def test_cli_drop_abort(clirunner, db, script_info, mocker):
+    mock_execute = mocker.patch.object(
+        db,
+        "_execute_for_all_tables",
+    )
+
+    result = clirunner.invoke(db_drop, input="n", obj=script_info)
+    assert result.exit_code == 1
+    assert result.output.startswith(
+        "This will destroy all the data in your database. "
+        "Do you want to continue? [y/N]:"
+    )
+    assert not mock_execute.called
+    assert "Database dropped successfully." not in result.output
+
+
+def test_cli_binds(clirunner, script_info, Todo):
+    result = clirunner.invoke(db_binds, obj=script_info)
+    assert result.exit_code == 0
+    assert "todos -> sqlite:///:memory:" in result.output
+
+
+def test_cli_binds_empty_db(clirunner, db, script_info):
+    result = clirunner.invoke(db_binds, obj=script_info)
+    assert result.exit_code == 1
+    assert "Error: No database tables found." in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import pytest
-from click.testing import CliRunner
+pytest.importorskip("click")
+
 from flask_sqlalchemy.cli import db_create, db_drop, db_binds
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 import pytest
 pytest.importorskip("click")
 
-from flask_sqlalchemy.cli import db_create, db_drop
+from flask_sqlalchemy.cli import db_create
 
 
 def test_cli_create(clirunner, db, script_info, mocker):
@@ -14,35 +14,3 @@ def test_cli_create(clirunner, db, script_info, mocker):
     assert result.exit_code == 0
     mock_execute.assert_called_once_with(None, '__all__', 'create_all')
     assert "Database created successfully." in result.output
-
-
-def test_cli_drop(clirunner, db, script_info, mocker):
-    mock_execute = mocker.patch.object(
-        db,
-        "_execute_for_all_tables",
-    )
-
-    result = clirunner.invoke(db_drop, input="y", obj=script_info)
-    assert result.exit_code == 0
-    assert result.output.startswith(
-        "This will destroy all the data in your database. "
-        "Do you want to continue? [y/N]:"
-    )
-    mock_execute.assert_called_once_with(None, '__all__', 'drop_all')
-    assert "Database dropped successfully." in result.output
-
-
-def test_cli_drop_abort(clirunner, db, script_info, mocker):
-    mock_execute = mocker.patch.object(
-        db,
-        "_execute_for_all_tables",
-    )
-
-    result = clirunner.invoke(db_drop, input="n", obj=script_info)
-    assert result.exit_code == 1
-    assert result.output.startswith(
-        "This will destroy all the data in your database. "
-        "Do you want to continue? [y/N]:"
-    )
-    assert not mock_execute.called
-    assert "Database dropped successfully." not in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 import pytest
 pytest.importorskip("click")
 
-from flask_sqlalchemy.cli import db_create, db_drop, db_binds
+from flask_sqlalchemy.cli import db_create, db_drop
 
 
 def test_cli_create(clirunner, db, script_info, mocker):
@@ -46,15 +46,3 @@ def test_cli_drop_abort(clirunner, db, script_info, mocker):
     )
     assert not mock_execute.called
     assert "Database dropped successfully." not in result.output
-
-
-def test_cli_binds(clirunner, script_info, Todo):
-    result = clirunner.invoke(db_binds, obj=script_info)
-    assert result.exit_code == 0
-    assert "todos -> sqlite:///:memory:" in result.output
-
-
-def test_cli_binds_empty_db(clirunner, db, script_info):
-    result = clirunner.invoke(db_binds, obj=script_info)
-    assert result.exit_code == 1
-    assert "Error: No database tables found." in result.output

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,9 @@ envlist =
 [testenv]
 deps =
     pytest>=3
+    pytest-mock
     coverage
     blinker
-
     lowest: flask==0.10
     lowest: sqlalchemy==0.8
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     pytest-mock
     coverage
     blinker
+
     lowest: flask==0.10
     lowest: sqlalchemy==0.8
 


### PR DESCRIPTION
Basic CLI support for Flask-SQLAlchemy, modeled after [the CLI support in Flask-Security](https://github.com/mattupstate/flask-security/blob/develop/flask_security/cli.py). Supports the following command:

* `flask db create`