### PR TITLE
check paginate  args page, per_page type

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -477,6 +477,22 @@ class BaseQuery(orm.Query):
         if max_per_page is not None:
             per_page = min(per_page, max_per_page)
 
+        try:
+            page = int(page)
+        except (TypeError, ValueError):
+            if error_out:
+                abort(404)
+
+            page = 1
+
+        try:
+            per_page = int(per_page)
+        except (TypeError, ValueError):
+            if error_out:
+                abort(404)
+
+            per_page = 20
+
         if page < 1:
             if error_out:
                 abort(404)


### PR DESCRIPTION
Documentation for flask_sqlalchemy paginate class

When error_out is True (default), the following rules will cause a 404 response:
- No items are found and page is not 1.
- page is less than 1, or per_page is negative.
- page or per_page are not ints.

But the paginate class does not have an implementation to check if the given page and per_page arguments are int.  