### PR TITLE
fix: MetaMixin* accept kwargs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Unreleased
 -   Deprecate ``SQLALCHEMY_COMMIT_ON_TEARDOWN`` as it can cause various
     design issues that are difficult to debug. Call
     ``db.session.commit()`` directly instead. :issue:`216`
+-   Support ``__init_subclass__()`` hooks in models :issue:`1002`
 
 
 Version 2.5.1

--- a/src/flask_sqlalchemy/model.py
+++ b/src/flask_sqlalchemy/model.py
@@ -48,11 +48,11 @@ def camel_to_snake_case(name):
 
 
 class NameMetaMixin(type):
-    def __init__(cls, name, bases, d):
+    def __init__(cls, name, bases, d, **kw):
         if should_set_tablename(cls):
             cls.__tablename__ = camel_to_snake_case(cls.__name__)
 
-        super().__init__(name, bases, d)
+        super().__init__(name, bases, d, **kw)
 
         # __table_cls__ has run at this point
         # if no table was created, use the parent table
@@ -99,10 +99,10 @@ class NameMetaMixin(type):
 
 
 class BindMetaMixin(type):
-    def __init__(cls, name, bases, d):
+    def __init__(cls, name, bases, d, **kw):
         bind_key = d.pop("__bind_key__", None) or getattr(cls, "__bind_key__", None)
 
-        super().__init__(name, bases, d)
+        super().__init__(name, bases, d, **kw)
 
         if bind_key is not None and getattr(cls, "__table__", None) is not None:
             cls.__table__.info["bind_key"] = bind_key

--- a/tests/test_model_class.py
+++ b/tests/test_model_class.py
@@ -62,3 +62,17 @@ def test_repr(db):
     db.session.flush()
     assert repr(r) == "<Report 2, test>"
     assert repr(u) == str(u)
+
+
+def test_subclass_hook(db):
+    class SomeMixin:
+        def __init_subclass__(cls, default=None, **kwargs):
+            super().__init_subclass__(**kwargs)
+
+            cls.default = default
+
+    class SomeModel(db.Model, SomeMixin, default=2):
+        id = db.Column(db.Integer, primary_key=True)
+
+    assert hasattr(SomeModel, 'default')
+    assert SomeModel.default == 2

--- a/tests/test_model_class.py
+++ b/tests/test_model_class.py
@@ -74,5 +74,5 @@ def test_subclass_hook(db):
     class SomeModel(db.Model, SomeMixin, default=2):
         id = db.Column(db.Integer, primary_key=True)
 
-    assert hasattr(SomeModel, 'default')
+    assert hasattr(SomeModel, "default")
     assert SomeModel.default == 2


### PR DESCRIPTION
The Metaclass Mixin classes now accept and propagate additional keywords provided.

The name `**kw` has been chosen to stay consistent with [SQLAlchemy](https://github.com/sqlalchemy/sqlalchemy/blob/master/lib/sqlalchemy/orm/decl_api.py#L56).

- fixes #1002

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
