### PR TITLE
Renaming master to main in CONTRIBUTING.rst, and adding a note regarding small issues.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -164,9 +164,7 @@ Start coding
     test fails without your patch. Run the tests as described below.
 -   Push your commits to your fork on GitHub and
     `create a pull request`_. Link to the issue being addressed with
-    ``fixes #123`` in the pull request. There is no need to open an
-    issue if your change does not effect code and is very simple like
-    a typo.
+    ``fixes #123`` in the pull request.
 
     .. code-block:: text
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -51,10 +51,12 @@ Submitting patches
 ------------------
 
 If there is not an open issue for what you want to submit, prefer
-opening one for discussion before working on a PR. You can work on any
-issue that doesn't have an open PR linked to it or a maintainer assigned
-to it. These show up in the sidebar. No need to ask if you can work on
-an issue that interests you.
+opening one for discussion before working on a PR. You do not need to
+open an issue if your change only effects documentation and is only a
+simple change such as a typo. You can work on any issue that doesn't
+have an open PR linked to it or a maintainer assigned to it. These
+show up in the sidebar. No need to ask if you can work on an issue that
+interests you.
 
 Include the following in your patch:
 
@@ -162,7 +164,9 @@ Start coding
     test fails without your patch. Run the tests as described below.
 -   Push your commits to your fork on GitHub and
     `create a pull request`_. Link to the issue being addressed with
-    ``fixes #123`` in the pull request.
+    ``fixes #123`` in the pull request. There is no need to open an
+    issue if your change does not effect code and is very simple like
+    a typo.
 
     .. code-block:: text
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -52,7 +52,7 @@ Submitting patches
 
 If there is not an open issue for what you want to submit, prefer
 opening one for discussion before working on a PR. You do not need to
-open an issue if your change only effects documentation and is only a
+open an issue if your change only affects documentation and is only a
 simple change such as a typo. You can work on any issue that doesn't
 have an open PR linked to it or a maintainer assigned to it. These
 show up in the sidebar. No need to ask if you can work on an issue that

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -149,12 +149,12 @@ Start coding
         $ git checkout -b your-branch-name origin/2.x
 
     If you're submitting a feature addition or change, branch off of the
-    "master" branch.
+    "main" branch.
 
     .. code-block:: text
 
         $ git fetch origin
-        $ git checkout -b your-branch-name origin/master
+        $ git checkout -b your-branch-name origin/main
 
 -   Using your favorite editor, make your changes,
     `committing as you go`_.


### PR DESCRIPTION
Creating some changes to CONTRIBUTING.rst

- fixes #1042 

I had opened an issue to rename master to main in the contributor's guide.
@ThiefMaster mentioned that there is no need to create an issue for such
a small change, and so I have since added a line to the contributor's guide
mentioning this.
