### PR TITLE
Fix bind reflection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Unreleased
     design issues that are difficult to debug. Call
     ``db.session.commit()`` directly instead. :issue:`216`
 -   Change the default MySQL character set to "utf8mb4". :issue:`875`
+-   Add `bind_key` to reflected tables. :issue:`660`
 
 
 Version 2.5.1

--- a/src/flask_sqlalchemy/__init__.py
+++ b/src/flask_sqlalchemy/__init__.py
@@ -1041,6 +1041,8 @@ class SQLAlchemy:
             if not skip_tables:
                 tables = self.get_tables_for_bind(bind)
                 extra["tables"] = tables
+            if operation == "reflect":
+                extra["info"] = {"bind_key": bind}
             op = getattr(self.Model.metadata, operation)
             op(bind=self.get_engine(app, bind), **extra)
 


### PR DESCRIPTION
Reflection is broken in extra binds, because of `bind_key` is not set for reflected tables.
Also `sqlalchemy>=0.9.2` is required. So fix may be backported to `2.x` branch if we can drop support for older versions.

- fixes #660

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
