### PR TITLE
Update docs dependencies

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -6,45 +6,45 @@
 #
 alabaster==0.7.12
     # via sphinx
-babel==2.9.1
+babel==2.10.3
     # via sphinx
-certifi==2021.10.8
+certifi==2022.6.15
     # via requests
-charset-normalizer==2.0.7
+charset-normalizer==2.1.0
     # via requests
-docutils==0.17.1
+docutils==0.19
     # via sphinx
 idna==3.3
     # via requests
-imagesize==1.2.0
+imagesize==1.4.1
     # via sphinx
-jinja2==3.0.2
+jinja2==3.1.2
     # via sphinx
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via jinja2
-packaging==21.2
+packaging==21.3
     # via
     #   pallets-sphinx-themes
     #   sphinx
-pallets-sphinx-themes==2.0.1
+pallets-sphinx-themes==2.0.2
     # via -r requirements/docs.in
-pygments==2.10.0
+pygments==2.12.0
     # via sphinx
-pyparsing==2.4.7
+pyparsing==3.0.9
     # via packaging
-pytz==2021.3
+pytz==2022.1
     # via babel
-requests==2.26.0
+requests==2.28.1
     # via sphinx
-snowballstemmer==2.1.0
+snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.2.0
+sphinx==5.1.1
     # via
     #   -r requirements/docs.in
     #   pallets-sphinx-themes
     #   sphinx-issues
     #   sphinxcontrib-log-cabinet
-sphinx-issues==1.2.0
+sphinx-issues==3.0.1
     # via -r requirements/docs.in
 sphinxcontrib-applehelp==1.0.2
     # via sphinx
@@ -60,8 +60,5 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-urllib3==1.26.7
+urllib3==1.26.11
     # via requests
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools


### PR DESCRIPTION
Currently doc builds appear broken. I think this is producing a poor signal:noise on this repo and probably making it harder for maintainers to handle PRs.

`pip-compile -U requirements/docs.in` to get latest.
Importantly, this picks up pallets-sphinx-themes==2.0.2 so that doc builds now work with the latest jinja2 versions.