### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/binds.rst
+++ b/docs/binds.rst
@@ -13,7 +13,7 @@ What are binds?  In SQLAlchemy speak a bind is something that can execute
 SQL statements and is usually a connection or engine.  In Flask-SQLAlchemy
 binds are always engines that are created for you automatically behind the
 scenes.  Each of these engines is then associated with a short key (the
-bind key).  This key is then used at model declaration time to assocate a
+bind key).  This key is then used at model declaration time to associate a
 model with a specific engine.
 
 If no bind key is specified for a model the default connection is used

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -120,8 +120,8 @@ by overriding the ``query_class`` class attribute on the model::
     class MyModel(db.Model):
         query_class = GetOrQuery
 
-In this case, the ``get_or`` method will be only availble on queries
-orginating from ``MyModel.query``.
+In this case, the ``get_or`` method will be only available on queries
+originating from ``MyModel.query``.
 
 
 Model Metaclass


### PR DESCRIPTION
There are small typos in:
- docs/binds.rst
- docs/customizing.rst

Fixes:
- Should read `originating` rather than `orginating`.
- Should read `available` rather than `availble`.
- Should read `associate` rather than `assocate`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md