### PR TITLE
pagination tweaks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,6 +78,7 @@ Unreleased
 -   Model classes and the ``db`` instance are available without imports in
     ``flask shell``. :issue:`1089`
 -   ``Pagination`` ``per_page`` cannot be 0. :issue:`1091`
+-   ``Pagination`` ``max_per_page`` defaults to 100. :issue:`1091`
 
 
 Version 2.5.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,7 @@ Unreleased
     :issue:`508, 944`
 -   Model classes and the ``db`` instance are available without imports in
     ``flask shell``. :issue:`1089`
+-   ``Pagination`` ``per_page`` cannot be 0. :issue:`1091`
 
 
 Version 2.5.1

--- a/src/flask_sqlalchemy/pagination.py
+++ b/src/flask_sqlalchemy/pagination.py
@@ -95,7 +95,7 @@ class Pagination:
             else:
                 page = 1
 
-        if per_page < 0:
+        if per_page < 1:
             if error_out:
                 abort(404)
             else:
@@ -127,8 +127,8 @@ class Pagination:
         :param max_per_page: The maximum allowed value for ``per_page``, to limit a
             user-provided value.
         :param error_out: Abort with a ``404 Not Found`` error if no items are returned
-            and ``page`` is not 1, or if ``page`` is less than 1 or ``per_page`` is
-            negative, or if either are not ints.
+            and ``page`` is not 1, or if ``page`` or ``per_page`` is less than 1, or if
+            either are not ints.
         :param count: Calculate the total number of values by issuing an extra count
             query. For very complex queries this may be inaccurate or slow, so it can be
             disabled and set manually if necessary.
@@ -137,6 +137,9 @@ class Pagination:
 
         .. versionchanged:: 3.0
             The ``count`` query is more efficient.
+
+        .. versionchanged:: 3.0
+            ``per_page`` cannot be 0.
         """
         page, per_page = cls._prepare_args(
             page=page,
@@ -170,7 +173,7 @@ class Pagination:
     @property
     def pages(self) -> int:
         """The total number of pages."""
-        if self.per_page == 0 or self.total is None:
+        if self.total is None:
             return 0
 
         return ceil(self.total / self.per_page)

--- a/src/flask_sqlalchemy/pagination.py
+++ b/src/flask_sqlalchemy/pagination.py
@@ -110,7 +110,7 @@ class Pagination:
         *,
         page: int | None = None,
         per_page: int | None = None,
-        max_per_page: int | None = None,
+        max_per_page: int | None = 100,
         error_out: bool = True,
         count: bool = True,
     ) -> Pagination:
@@ -125,7 +125,7 @@ class Pagination:
             offset and limit. Defaults to the ``per_page`` query arg during a request,
             or 20 otherwise.
         :param max_per_page: The maximum allowed value for ``per_page``, to limit a
-            user-provided value.
+            user-provided value. Use ``None`` for no limit. Defaults to 100.
         :param error_out: Abort with a ``404 Not Found`` error if no items are returned
             and ``page`` is not 1, or if ``page`` or ``per_page`` is less than 1, or if
             either are not ints.
@@ -140,6 +140,9 @@ class Pagination:
 
         .. versionchanged:: 3.0
             ``per_page`` cannot be 0.
+
+        .. versionchanged:: 3.0
+            ``max_per_page`` defaults to 100.
         """
         page, per_page = cls._prepare_args(
             page=page,

--- a/src/flask_sqlalchemy/query.py
+++ b/src/flask_sqlalchemy/query.py
@@ -72,7 +72,6 @@ class Query(sa.orm.Query):  # type: ignore[type-arg]
         """Apply an offset and limit to the query based on the current page and number
         of items per page, returning a :class:`.Pagination` object.
 
-        :param query: The query to paginate.
         :param page: The current page, used to calculate the offset. Defaults to the
             ``page`` query arg during a request, or 1 otherwise.
         :param per_page: The maximum number of items on a page, used to calculate the
@@ -81,9 +80,8 @@ class Query(sa.orm.Query):  # type: ignore[type-arg]
         :param max_per_page: The maximum allowed value for ``per_page``, to limit a
             user-provided value.
         :param error_out: Abort with a ``404 Not Found`` error if no items are returned
-            and ``page`` is not 1, or if ``page`` is less than 1 or ``per_page`` is
-            negative, or if either are not ints. If disabled, an invalid ``page``
-            defaults to 1, and ``per_page`` defaults to 20.
+            and ``page`` is not 1, or if ``page`` or ``per_page`` is less than 1, or if
+            either are not ints.
         :param count: Calculate the total number of values by issuing an extra count
             query. For very complex queries this may be inaccurate or slow, so it can be
             disabled and set manually if necessary.
@@ -93,6 +91,9 @@ class Query(sa.orm.Query):  # type: ignore[type-arg]
 
         .. versionchanged:: 3.0
             The ``count`` query is more efficient.
+
+        .. versionchanged:: 3.0
+            All parameters are keyword-only.
         """
         return Pagination.apply_to_query(
             self,

--- a/src/flask_sqlalchemy/query.py
+++ b/src/flask_sqlalchemy/query.py
@@ -78,7 +78,7 @@ class Query(sa.orm.Query):  # type: ignore[type-arg]
             offset and limit. Defaults to the ``per_page`` query arg during a request,
             or 20 otherwise.
         :param max_per_page: The maximum allowed value for ``per_page``, to limit a
-            user-provided value.
+            user-provided value. Use ``None`` for no limit. Defaults to 100.
         :param error_out: Abort with a ``404 Not Found`` error if no items are returned
             and ``page`` is not 1, or if ``page`` or ``per_page`` is less than 1, or if
             either are not ints.
@@ -94,6 +94,9 @@ class Query(sa.orm.Query):  # type: ignore[type-arg]
 
         .. versionchanged:: 3.0
             All parameters are keyword-only.
+
+        .. versionchanged:: 3.0
+            ``max_per_page`` defaults to 100.
         """
         return Pagination.apply_to_query(
             self,

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -40,7 +40,6 @@ def test_last_page() -> None:
 @pytest.mark.parametrize(
     ("per_page", "total"),
     [
-        (0, 150),
         (10, 0),
         (10, None),
     ],


### PR DESCRIPTION
fixes #1091 

* `per_page` cannot be 0.
* `max_per_page` defaults to 100.