### PR TITLE
sqlite driver-level uri

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,6 +83,8 @@ Unreleased
     ``app.testing``. :issue:`1092`
 -   MySQL engines don't set a default for ``pool_recycle`` if not using a queue pool.
     :issue:`803`
+-   SQLite driver-level URIs that look like ``sqlite:///file:name.db?uri=true`` are
+    supported. :issue:`998, 1045`
 
 
 Version 2.5.1

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -89,6 +89,16 @@ def test_sqlite_relative_path(app: Flask) -> None:
     assert os.path.exists(db_path)  # type: ignore[arg-type]
 
 
+@pytest.mark.usefixtures("app_ctx")
+def test_sqlite_driver_level_uri(app: Flask) -> None:
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///file:test.db?uri=true"
+    db = SQLAlchemy(app)
+    db.create_all()
+    db_path = db.engine.url.database
+    assert db_path.startswith(f"file:{app.instance_path}")  # type: ignore[union-attr]
+    assert os.path.exists(db_path[5:])  # type: ignore[arg-type]
+
+
 @unittest.mock.patch.object(SQLAlchemy, "_make_engine", autospec=True)
 def test_sqlite_memory_defaults(make_engine: unittest.mock.Mock, app: Flask) -> None:
     SQLAlchemy(app)


### PR DESCRIPTION
If the SQLite URL has `uri=true` in the query, it is a "driver-level URI" that will start with `file:`, like `sqlite:///file:path.db?uri=true`. Detect this when checking relative paths and creating the instance folder.

fixes #998
fixes #1045