### PR TITLE
pagination first and last item number

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -85,6 +85,8 @@ Unreleased
     :issue:`803`
 -   SQLite driver-level URIs that look like ``sqlite:///file:name.db?uri=true`` are
     supported. :issue:`998, 1045`
+-   Added ``Pagination.first`` and ``last`` properties, which give the number of the
+    first and last item on the page. :issue:`567`
 
 
 Version 2.5.1

--- a/docs/pagination.rst
+++ b/docs/pagination.rst
@@ -50,11 +50,18 @@ pages and the current page is 7, the following values are yielded.
     users.iter_pages()
     [1, 2, None, 5, 6, 7, 8, 9, 10, 11, None, 19, 20]
 
+You can use the :attr:`~.Pagination.total` attribute to show the total number of
+results, and :attr:`~.Pagination.first` and :attr:`~.Pagination.last` to show the
+range of items on the current page.
+
 The following Jinja macro renders a simple pagination widget.
 
 .. code-block:: jinja
 
     {% macro render_pagination(pagination, endpoint) %}
+      <div class=page-items>
+        {{ page.first }} - {{ page.last }} of {{ page.total }}
+      </div>
       <div class=pagination>
         {% for page in pagination.iter_pages() %}
           {% if page %}
@@ -69,6 +76,3 @@ The following Jinja macro renders a simple pagination widget.
         {% endfor %}
       </div>
     {% endmacro %}
-
-You might also use the :attr:`~.Pagination.total` attribute to show the total number of
-results.

--- a/src/flask_sqlalchemy/pagination.py
+++ b/src/flask_sqlalchemy/pagination.py
@@ -174,9 +174,31 @@ class Pagination:
     # TODO: apply_to_select, requires access to session
 
     @property
+    def first(self) -> int:
+        """The number of the first item on the page, starting from 1, or 0 if there are
+        no items.
+
+        .. versionadded:: 3.0
+        """
+        if len(self.items) == 0:
+            return 0
+
+        return (self.page - 1) * self.per_page + 1
+
+    @property
+    def last(self) -> int:
+        """The number of the last item on the page, starting from 1, inclusive, or 0 if
+        there are no items.
+
+        .. versionadded:: 3.0
+        """
+        first = self.first
+        return max(first, first + len(self.items) - 1)
+
+    @property
     def pages(self) -> int:
         """The total number of pages."""
-        if self.total is None:
+        if self.total == 0 or self.total is None:
             return 0
 
         return ceil(self.total / self.per_page)

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -37,6 +37,26 @@ def test_last_page() -> None:
     assert p.next_num is None
 
 
+def test_item_numbers_first_page() -> None:
+    p = _make_page()
+    p.items = list(range(10))
+    assert p.first == 1
+    assert p.last == 10
+
+
+def test_item_numbers_last_page() -> None:
+    p = _make_page(page=15)
+    p.items = list(range(5))
+    assert p.first == 141
+    assert p.last == 145
+
+
+def test_item_numbers_0() -> None:
+    p = _make_page(total=0)
+    assert p.first == 0
+    assert p.last == 0
+
+
 @pytest.mark.parametrize(
     ("per_page", "total"),
     [


### PR DESCRIPTION
Adds `first` and `last` properties to `Pagination`. These give the number of the first and last item on the page, so you can display something like `showing first - last of total`.

fixes #567