### PR TITLE
prerelease 3.0.0a1

### DIFF
--- a/src/flask_sqlalchemy/__init__.py
+++ b/src/flask_sqlalchemy/__init__.py
@@ -4,7 +4,7 @@ import typing as t
 
 from .extension import SQLAlchemy
 
-__version__ = "3.0.0.dev0"
+__version__ = "3.0.0a1"
 
 __all__ = [
     "SQLAlchemy",


### PR DESCRIPTION
This is the first prerelease to preview the changes in 3.0. There were significant changes in #1087, see the changelog for a full list. Many of those changes will raise deprecation warnings, but it was not feasible to implement warnings for some things. The prereleases are an opportunity to report any breaking changes *that can't be adapted to*.