### PR TITLE
use metadata from custom declarative base class

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,6 +36,6 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - run: |
-          pip install pdm
+          pip install pdm "importlib-metadata<5"
           pdm sync -dG tox
       - run: pdm run tox -e ${{ matrix.tox }}


### PR DESCRIPTION
If `model_class` is a fully created declarative base, use its `metadata` as the default metadata instead of replacing it with another blank one. If both `metadata` and `model_class` are passed in, the custom metadata will be used, replacing the model's.

Otherwise, you'd need to pass the metadata twice, like `SQLAlchemy(model_class=declarative_base(metadata=metadata), metadata=metadata)`, to get the model and extension to use the custom metadata. Now you can leave off the metadata argument to the extension.