### PR TITLE
remove previously deprecated code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Version 3.1.0
 
 Unreleased
 
+-   Remove previously deprecated code.
+
 
 Version 3.0.0
 -------------

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -78,13 +78,8 @@ must happen before initializing the application.
 
     .. versionadded:: 2.0
 
-.. data:: SQLALCHEMY_COMMIT_ON_TEARDOWN
-
-    Call ``db.session.commit()`` automatically if the request finishes without an
-    unhandled exception.
-
-    .. deprecated:: 3.0
-        Will be removed in Flask-SQLAlchemy 3.1.
+.. versionchanged:: 3.1
+    Removed ``SQLALCHEMY_COMMIT_ON_TEARDOWN``.
 
 .. versionchanged:: 3.0
     Removed ``SQLALCHEMY_NATIVE_UNICODE``, ``SQLALCHEMY_POOL_SIZE``,

--- a/src/flask_sqlalchemy/__init__.py
+++ b/src/flask_sqlalchemy/__init__.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import typing as t
-
 from .extension import SQLAlchemy
 
 __version__ = "3.1.0.dev"
@@ -9,38 +7,3 @@ __version__ = "3.1.0.dev"
 __all__ = [
     "SQLAlchemy",
 ]
-
-_deprecated_map = {
-    "Model": ".model.Model",
-    "DefaultMeta": ".model.DefaultMeta",
-    "Pagination": ".pagination.Pagination",
-    "BaseQuery": ".query.Query",
-    "get_debug_queries": ".record_queries.get_recorded_queries",
-    "SignallingSession": ".session.Session",
-    "before_models_committed": ".track_modifications.before_models_committed",
-    "models_committed": ".track_modifications.models_committed",
-}
-
-
-def __getattr__(name: str) -> t.Any:
-    import importlib
-    import warnings
-
-    if name in _deprecated_map:
-        path = _deprecated_map[name]
-        import_path, _, new_name = path.rpartition(".")
-        action = "moved and renamed"
-
-        if new_name == name:
-            action = "moved"
-
-        warnings.warn(
-            f"'{name}' has been {action} to '{path[1:]}'. The top-level import is"
-            " deprecated and will be removed in Flask-SQLAlchemy 3.1.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        mod = importlib.import_module(import_path, __name__)
-        return getattr(mod, new_name)
-
-    raise AttributeError(name)

--- a/src/flask_sqlalchemy/model.py
+++ b/src/flask_sqlalchemy/model.py
@@ -18,14 +18,6 @@ class _QueryProperty:
     :meta private:
     """
 
-    @t.overload
-    def __get__(self, obj: None, cls: t.Type[Model]) -> Query:
-        ...
-
-    @t.overload
-    def __get__(self, obj: Model, cls: t.Type[Model]) -> Query:
-        ...
-
     def __get__(self, obj: Model | None, cls: t.Type[Model]) -> Query:
         return cls.query_class(
             cls, session=cls.__fsa__.session()  # type: ignore[arg-type]

--- a/src/flask_sqlalchemy/record_queries.py
+++ b/src/flask_sqlalchemy/record_queries.py
@@ -70,30 +70,6 @@ class _QueryInfo:
     def duration(self) -> float:
         return self.end_time - self.start_time
 
-    @property
-    def context(self) -> str:
-        import warnings
-
-        warnings.warn(
-            "'context' is renamed to 'location'. The old name is deprecated and will be"
-            " removed in Flask-SQLAlchemy 3.1.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.location
-
-    def __getitem__(self, key: int) -> object:
-        import warnings
-
-        name = ("statement", "parameters", "start_time", "end_time", "location")[key]
-        warnings.warn(
-            "Query info is a dataclass, not a tuple. Lookup by index is deprecated and"
-            f" will be removed in Flask-SQLAlchemy 3.1. Use 'info.{name}' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return getattr(self, name)
-
 
 def _listen(engine: sa.engine.Engine) -> None:
     sa.event.listen(engine, "before_cursor_execute", _record_start, named=True)


### PR DESCRIPTION
* Remove compatibility aliases for moved or renamed imports.
* Remove `COMMIT_ON_TEARDOWN`.
* Remove setting bind key through `Table.info`.
* Remove `get_engine`, `get_tables_for_bind`, and `get_binds` methods.
* Remove `db.db` alias.
* Remove `context` alias and tuple behavior from recorded query info objects.