### PR TITLE
update CI config, cache PDM

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,7 +28,6 @@ jobs:
           - {name: '3.9', python: '3.9', tox: py39}
           - {name: '3.8', python: '3.8', tox: py38}
           - {name: '3.7', python: '3.7', tox: py37}
-          - {name: 'PyPy 3.9', python: 'pypy3.9', tox: pypy39}
           - {name: 'Typing', python: '3.10', os: ubuntu-latest, tox: typing}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,6 +25,7 @@ jobs:
       matrix:
         include:
           - {name: '3.10', python: '3.10', tox: py310}
+          - {name: 'Lowest', python: '3.10', tox: py310-lowest}
           - {name: '3.9', python: '3.9', tox: py39}
           - {name: '3.8', python: '3.8', tox: py38}
           - {name: '3.7', python: '3.7', tox: py37}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,6 +36,6 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - run: |
-          pip install pdm "importlib-metadata<5"
+          pip install pdm
           pdm sync -dG tox
       - run: pdm run tox -e ${{ matrix.tox }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,7 +35,15 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+          cache: 'pip'
+          cache-dependency-path: 'pdm.lock'
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/pdm
+          key: ${{ matrix.python }}-pdm-${{ hashFiles('pdm.lock') }}
+          restore-keys: ${{ matrix.python }}-pdm-
       - run: |
           pip install pdm
+          pdm config install.cache true
           pdm sync -dG tox
       - run: pdm run tox -e ${{ matrix.tox }}


### PR DESCRIPTION
* PDM fixed compatibility with importlib-metadata, remove the restriction.
* Remove the PyPy CI env, we don't do anything specific to PyPy and it's the slowest test.
* Add a "lowest requirements" CI env, that runs `tox -e py310-lowest`. This helps remain compatible with the lowest supported versions of Flask and SQLAlchemy.
* Enable PDM's install cache and restore it with actions/cache.