### PR TITLE
add py.typed marker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@ Version 3.0.1
 
 Unreleased
 
+-   Export typing information instead of using external typeshed definitions.
+    :issue:`1112`
+
 
 Version 3.0.0
 -------------


### PR DESCRIPTION
Export typing information instead of using typeshed.

MyPy and PyRight both show an error when inheriting from `db.Model`. However, based on the discussion in #1112, the user experience should be the same whether we stick with typeshed or export our own types.

These are the relevant MyPy and PyRight issues. If you don't like that you need to ignore every `class User(db.Model)` line, you'll need to provide feedback to those projects.

- https://github.com/python/mypy/issues/8603
- https://github.com/microsoft/pyright/issues/2058

closes #1112