### PR TITLE
skip invalid default bind

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Unreleased
 
 -   Export typing information instead of using external typeshed definitions.
     :issue:`1112`
+-   If default engine options are set, but ``SQLALCHEMY_DATABASE_URI`` is not set, an
+    invalid default bind will not be configured. :issue:`1117`
 
 
 Version 3.0.0

--- a/src/flask_sqlalchemy/extension.py
+++ b/src/flask_sqlalchemy/extension.py
@@ -294,7 +294,7 @@ class SQLAlchemy:
         if basic_uri is not None:
             basic_engine_options["url"] = basic_uri
 
-        if basic_engine_options:
+        if "url" in basic_engine_options:
             engine_options.setdefault(None, {}).update(basic_engine_options)
 
         if not engine_options:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -68,7 +68,7 @@ def test_url_type(app: Flask, value: str | sa.engine.URL) -> None:
     assert str(db.engines["a"].url) == "sqlite://"
 
 
-def test_no_default_url(app: Flask) -> None:
+def test_no_binds_error(app: Flask) -> None:
     del app.config["SQLALCHEMY_DATABASE_URI"]
 
     with pytest.raises(RuntimeError) as info:
@@ -76,6 +76,15 @@ def test_no_default_url(app: Flask) -> None:
 
     e = "Either 'SQLALCHEMY_DATABASE_URI' or 'SQLALCHEMY_BINDS' must be set."
     assert str(info.value) == e
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_no_default_url(app: Flask) -> None:
+    del app.config["SQLALCHEMY_DATABASE_URI"]
+    app.config["SQLALCHEMY_BINDS"] = {"a": "sqlite://"}
+    db = SQLAlchemy(app, engine_options={"echo": True})
+    assert None not in db.engines
+    assert "a" in db.engines
 
 
 @pytest.mark.usefixtures("app_ctx")


### PR DESCRIPTION
If default engine options were set, but `SQLALCHEMY_DATABASE_URI` was not, engine options for the default bind could be added without a URL, causing a `KeyError` during configuration. Now, the default bind config is not added if it doesn't have a `"url"` key.

fixes #1117 