### PR TITLE
update compatibility with sqlalchemy 2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Version 3.0.2
 
 Unreleased
 
+-   Update compatibility with SQLAlchemy 2. :issue:`1122`
+
 
 Version 3.0.1
 -------------

--- a/src/flask_sqlalchemy/extension.py
+++ b/src/flask_sqlalchemy/extension.py
@@ -978,8 +978,11 @@ class SQLAlchemy:
         if name == "event":
             return sa.event
 
+        if name.startswith("_"):
+            raise AttributeError(name)
+
         for mod in (sa, sa.orm):
-            if name in mod.__all__:
+            if hasattr(mod, name):
                 return getattr(mod, name)
 
         raise AttributeError(name)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -92,7 +92,7 @@ def test_sqlite_relative_path(app: Flask) -> None:
     app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///test.db"
     db = SQLAlchemy(app)
     db.create_all()
-    assert isinstance(db.engine.pool, sa.pool.NullPool)
+    assert not isinstance(db.engine.pool, sa.pool.StaticPool)
     db_path = db.engine.url.database
     assert db_path.startswith(app.instance_path)  # type: ignore[union-attr]
     assert os.path.exists(db_path)  # type: ignore[arg-type]

--- a/tests/test_legacy_query.py
+++ b/tests/test_legacy_query.py
@@ -1,14 +1,27 @@
 from __future__ import annotations
 
 import typing as t
+import warnings
 
 import pytest
 import sqlalchemy as sa
+import sqlalchemy.exc
 from flask import Flask
 from werkzeug.exceptions import NotFound
 
 from flask_sqlalchemy import SQLAlchemy
 from flask_sqlalchemy.query import Query
+
+
+@pytest.fixture(autouse=True)
+def ignore_query_warning() -> t.Generator[None, None, None]:
+    if hasattr(sa.exc, "LegacyAPIWarning"):
+        with warnings.catch_warnings():
+            exc = sa.exc.LegacyAPIWarning  # type: ignore[attr-defined]
+            warnings.simplefilter("ignore", exc)
+            yield
+    else:
+        yield
 
 
 @pytest.mark.usefixtures("app_ctx")

--- a/tests/test_model_name.py
+++ b/tests/test_model_name.py
@@ -154,7 +154,7 @@ def test_complex_inheritance(db: SQLAlchemy) -> None:
 
     class IdMixin:
         @sa.orm.declared_attr
-        def id(cls) -> sa.Column[sa.Integer]:  # noqa: B902
+        def id(cls):  # type: ignore[no-untyped-def]  # noqa: B902
             return sa.Column(sa.Integer, sa.ForeignKey(Duck.id), primary_key=True)
 
     class RubberDuck(IdMixin, Duck):  # type: ignore[misc]


### PR DESCRIPTION
A few changes in the latest SQLAlchemy 2 preview:

- SQLAlchemy no longer sets `__all__`.
- SQLite uses `QueuePool` instead of `NullPool`.
- Ignore `LegacyAPIWarning` when testing the legacy API. The lowest supported version, 1.4.18, does not have this class.
- Can't use `sa.Column[sa.Integer]` as a type, ignore it in the one test that uses it.

fixes #1122 