### PR TITLE
fix typo

### DIFF
--- a/docs/contexts.rst
+++ b/docs/contexts.rst
@@ -34,7 +34,7 @@ the following error.
 
 If you find yourself in a situation where you need the database and don't have a
 context, you can push one with ``app_context``. This is common when calling
-``db.create_all`` to creat the tables, for example.
+``db.create_all`` to create the tables, for example.
 
 .. code-block:: python
 


### PR DESCRIPTION
Hi!

This typo affects both [`latest`](https://flask-sqlalchemy.palletsprojects.com/en/latest/contexts/) and [`3.0.x`](https://flask-sqlalchemy.palletsprojects.com/en/3.0.x/contexts/) doc versions (according to online webpage). I didn't open a issue because of laziness (for just 1 letter...)

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist: Only docs were changed