### PR TITLE
Use the pagination parameter

### DIFF
--- a/docs/pagination.rst
+++ b/docs/pagination.rst
@@ -59,7 +59,7 @@ The following Jinja macro renders a simple pagination widget.
 
     {% macro render_pagination(pagination, endpoint) %}
       <div class=page-items>
-        {{ page.first }} - {{ page.last }} of {{ page.total }}
+        {{ pagination.first }} - {{ pagination.last }} of {{ pagination.total }}
       </div>
       <div class=pagination>
         {% for page in pagination.iter_pages() %}


### PR DESCRIPTION
Corrects argument references in the example macro in pagination.

- fixes #1126
