### PR TITLE
Rename `first_or_404` and `one_or_404` to `scalar_or_404` and `scalar_one_or_404`

### DIFF
--- a/src/flask_sqlalchemy/extension.py
+++ b/src/flask_sqlalchemy/extension.py
@@ -640,7 +640,7 @@ class SQLAlchemy:
 
         return value
 
-    def first_or_404(
+    def scalar_or_404(
         self, statement: sa.sql.Select[t.Any], *, description: str | None = None
     ) -> t.Any:
         """Like :meth:`Result.scalar() <sqlalchemy.engine.Result.scalar>`, but aborts
@@ -648,6 +648,9 @@ class SQLAlchemy:
 
         :param statement: The ``select`` statement to execute.
         :param description: A custom message to show on the error page.
+
+        .. versionchanged:: 3.1
+            Renamed from ``first_or_404()`` to ``scalar_or_404()``.
 
         .. versionadded:: 3.0
         """
@@ -658,7 +661,9 @@ class SQLAlchemy:
 
         return value
 
-    def one_or_404(
+    first_or_404 = scalar_or_404
+
+    def scalar_one_or_404(
         self, statement: sa.sql.Select[t.Any], *, description: str | None = None
     ) -> t.Any:
         """Like :meth:`Result.scalar_one() <sqlalchemy.engine.Result.scalar_one>`,
@@ -668,12 +673,17 @@ class SQLAlchemy:
         :param statement: The ``select`` statement to execute.
         :param description: A custom message to show on the error page.
 
+        .. versionchanged:: 3.1
+            Renamed from ``one_or_404()`` to ``scalar_one_or_404()``.
+
         .. versionadded:: 3.0
         """
         try:
             return self.session.execute(statement).scalar_one()
         except (sa.exc.NoResultFound, sa.exc.MultipleResultsFound):
             abort(404, description=description)
+
+    one_or_404 = scalar_one_or_404
 
     def paginate(
         self,


### PR DESCRIPTION
The underly implementation of `first_or_404` and `one_or_404` is use `scalar()` and `scalar_one()`. I think it will be more clear to rename them to `scalar_or_404` and `scalar_one_or_404`, so users won't expect or worry `first_or_404` and `one_or_404` will return a Row object/tuple.

It seems reasonable to change the old names to match the new behaviors of SQLAlchemy 2.x style. The old names can be kept for backward compatibility.

I will add the tests, and update the docs if this change will be accepted.

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
