### PR TITLE
Fixed documentation typo

### DIFF
--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -21,7 +21,7 @@ joined-table inheritance.
 
 .. code-block:: python
 
-    from flask_sqlalchemy.model import model
+    from flask_sqlalchemy.model import Model
     import sqlalchemy as sa
     import sqlalchemy.orm
 


### PR DESCRIPTION
I believe there was a typo in the documentation, as `Model` is used later in the code, and `flask_sqlalchemy.model.model` is not an actual object you can import