### PR TITLE
Docs change: Make the intent of the example more clear

### DIFF
--- a/docs/contexts.rst
+++ b/docs/contexts.rst
@@ -78,13 +78,13 @@ a context for a specific test.
 
     import pytest
 
-    @pytest.mark.fixture
+    @pytest.fixture
     def app_ctx(app):
         with app.app_context():
             yield
 
     @pytest.mark.usefixtures("app_ctx")
-    def test_user_model(app):
+    def test_user_model():
         user = User()
         db.session.add(user)
         db.session.commit()


### PR DESCRIPTION
The `app` argument is no longer needed in the `test_user_model()`  once the context of the app is loaded by `app_ctx` fixture, so removing the `app` argument will make the intent of this example more clear. Additionally, `pytest.mark.fixture` is not available in the latest Pytest. I replace it with `pytest.fixture`.


**Only the docs were changed**.


