### PR TITLE
Pagination per_page gets wrong value after calling next() #1201

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+Version 3.0.5
+-------------
+
+Unreleased
+
+-   ``Pagination.next()`` enforces ``max_per_page``. :issue:`1201`
+
+
 Version 3.0.4
 -------------
 

--- a/src/flask_sqlalchemy/pagination.py
+++ b/src/flask_sqlalchemy/pagination.py
@@ -66,6 +66,9 @@ class Pagination:
         self.per_page: int = per_page
         """The maximum number of items on a page."""
 
+        self.max_per_page: int | None = max_per_page
+        """The maximum allowed value for `per_page`"""
+
         items = self._query_items()
 
         if not items and page != 1 and error_out:
@@ -249,6 +252,7 @@ class Pagination:
         p = type(self)(
             page=self.page + 1,
             per_page=self.per_page,
+            max_per_page=self.max_per_page,
             error_out=error_out,
             count=False,
             **self._query_args,

--- a/src/flask_sqlalchemy/pagination.py
+++ b/src/flask_sqlalchemy/pagination.py
@@ -67,7 +67,7 @@ class Pagination:
         """The maximum number of items on a page."""
 
         self.max_per_page: int | None = max_per_page
-        """The maximum allowed value for `per_page`"""
+        """The maximum allowed value for ``per_page``."""
 
         items = self._query_items()
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -174,7 +174,7 @@ def test_paginate_max(paginate: _PaginateCallable) -> None:
 
 
 @pytest.mark.usefixtures("app_ctx")
-def test_paginate_max2(paginate: _PaginateCallable) -> None:
+def test_next_page_size(paginate: _PaginateCallable) -> None:
     p = paginate(per_page=110, max_per_page=250)
     assert p.page == 1
     assert p.per_page == 110

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -145,7 +145,7 @@ class _PaginateCallable:
 @pytest.fixture
 def paginate(app: Flask, db: SQLAlchemy, Todo: t.Any) -> _PaginateCallable:
     with app.app_context():
-        for i in range(1, 101):
+        for i in range(1, 251):
             db.session.add(Todo(title=f"task {i}"))
 
         db.session.commit()
@@ -158,8 +158,8 @@ def test_paginate(paginate: _PaginateCallable) -> None:
     assert p.page == 1
     assert p.per_page == 20
     assert len(p.items) == 20
-    assert p.total == 100
-    assert p.pages == 5
+    assert p.total == 250
+    assert p.pages == 13
 
 
 def test_paginate_qs(paginate: _PaginateCallable) -> None:
@@ -171,6 +171,16 @@ def test_paginate_qs(paginate: _PaginateCallable) -> None:
 def test_paginate_max(paginate: _PaginateCallable) -> None:
     p = paginate(per_page=100, max_per_page=50)
     assert p.per_page == 50
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_paginate_max2(paginate: _PaginateCallable) -> None:
+    p = paginate(per_page=110, max_per_page=250)
+    assert p.page == 1
+    assert p.per_page == 110
+    p = p.next()
+    assert p.page == 2
+    assert p.per_page == 110
 
 
 def test_no_count(paginate: _PaginateCallable) -> None:


### PR DESCRIPTION
The `Pagination` `max_per_page` value should be carried into the next `Pagination` object when calling `next()`

- fixes #1201

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
