### PR TITLE
Add .pdm-python to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ env/
 venv/
 .venv/
 .pdm.toml
+.pdm-python


### PR DESCRIPTION
This PR adds .pdm-python to .gitignore. I made that change in my other PRs as well, but it's not particular to those PRs, so better to make it in a separate independent one.

Here's what the pdm docs say about it:
https://pdm.fming.dev/latest/usage/project/#working-with-version-control

"You must commit the pyproject.toml file. You should commit the pdm.lock and pdm.toml file. Do not commit the .pdm-python file."

So it agrees that .pdm-python should not be committed.


Checklist: (None relevant)

- ~Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.~
- ~Add or update relevant docs, in the docs folder and in code.~
- ~Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.~
- ~Add `.. versionchanged::` entries in any relevant code docs.~
- ~Run `pre-commit` hooks and fix any issues.~
- ~Run `pytest` and `tox`, no tests failed.~
