### PR TITLE
Improve type hint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+Version 3.0.5
+-------------
+
+Unreleased
+
+-   Improve type hint for ``get_or_404`` return value to be non-optional. :pr:`120?`
+
+
 Version 3.0.4
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Version 3.0.5
 Unreleased
 
 -   ``Pagination.next()`` enforces ``max_per_page``. :issue:`1201`
--   Improve type hint for ``get_or_404`` return value to be non-optional. :pr:`120?`
+-   Improve type hint for ``get_or_404`` return value to be non-optional. :pr:`1226`
 
 
 Version 3.0.4

--- a/src/flask_sqlalchemy/extension.py
+++ b/src/flask_sqlalchemy/extension.py
@@ -734,7 +734,7 @@ class SQLAlchemy:
 
     def get_or_404(
         self, entity: type[_O], ident: t.Any, *, description: str | None = None
-    ) -> t.Optional[_O]:
+    ) -> _O:
         """Like :meth:`session.get() <sqlalchemy.orm.Session.get>` but aborts with a
         ``404 Not Found`` error instead of returning ``None``.
 

--- a/tests/test_view_query.py
+++ b/tests/test_view_query.py
@@ -70,11 +70,11 @@ def test_view_get_or_404_typed(db: SQLAlchemy, app: Flask) -> None:
 
     db.create_all()
 
-    item: Quiz = Quiz()
+    item: Quiz = Quiz(topic="Python")
     db.session.add(item)
     db.session.commit()
     result = db.get_or_404(Quiz, 1)
-    assert result.topic == ""
+    assert result.topic == "Python"
     assert result is item
     if hasattr(t, "assert_type"):
         t.assert_type(result, Quiz)

--- a/tests/test_view_query.py
+++ b/tests/test_view_query.py
@@ -74,6 +74,7 @@ def test_view_get_or_404_typed(db: SQLAlchemy, app: Flask) -> None:
     db.session.add(item)
     db.session.commit()
     result = db.get_or_404(Quiz, 1)
+    assert result.topic == ""
     assert result is item
     if hasattr(t, "assert_type"):
         t.assert_type(result, Quiz)


### PR DESCRIPTION
Thanks to a new test in main, I discovered that the return type of get_or_404 should *not* be Optional. I had chosen Optional since it can raise exceptions, but I've now learnt that Python typing does not document exception raising.

Checklist:

- [X] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] ~Add or update relevant docs, in the docs folder and in code.~
- [X] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] ~Add `.. versionchanged::` entries in any relevant code docs.~
- [X] Run `pre-commit` hooks and fix any issues.
- [X] Run `pytest` and `tox`, no tests failed.
