### PR TITLE
drop Python 3.7 support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,7 +29,6 @@ jobs:
           - {name: '3.10', python: '3.10', tox: py310}
           - {name: '3.9', python: '3.9', tox: py39}
           - {name: '3.8', python: '3.8', tox: py38}
-          - {name: '3.7', python: '3.7', tox: py37}
           - {name: 'Typing', python: '3.11', tox: typing}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,18 +6,18 @@ repos:
     rev: v3.7.0
     hooks:
       - id: pyupgrade
-        args: ["--py37-plus"]
+        args: ["--py38-plus"]
   - repo: https://github.com/asottile/reorder-python-imports
     rev: v3.10.0
     hooks:
       - id: reorder-python-imports
         files: "^(?!examples/)"
-        args: ["--py37-plus", "--application-directories", "src"]
+        args: ["--py38-plus", "--application-directories", "src"]
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:
       - id: black
-        args: ["--target-version", "py37"]
+        args: ["--target-version", "py38"]
   - repo: https://github.com/PyCQA/flake8
     rev: 6.0.0
     hooks:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Version 3.1.0
 
 Unreleased
 
+-   Drop support for Python 3.7.  :pr:`1251`
 -   Add support for the SQLAlchemy 2.x API via ``model_class`` parameter. :issue:`1140`
 -   Bump minimum version of SQLAlchemy to 2.0.16.
 -   Remove previously deprecated code.

--- a/examples/flaskr/setup.cfg
+++ b/examples/flaskr/setup.cfg
@@ -12,7 +12,7 @@ long_description = file: README.rst
 [options]
 packages = find:
 include_package_data = true
-python_requires = >= 3.7
+python_requires = >= 3.8
 install_requires =
     Flask>=2.2
     Flask-SQLAlchemy>=3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Programming Language :: Python",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "flask>=2.2.5",
     "sqlalchemy>=2.0.16",
@@ -59,7 +59,7 @@ source = ["flask_sqlalchemy", "tests"]
 source = ["src", "*/site-packages"]
 
 [tool.mypy]
-python_version = "3.7"
+python_version = "3.8"
 files = ["src/flask_sqlalchemy", "tests"]
 show_error_codes = true
 pretty = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py3{11,10,9,8,7}
+    py3{11,10,9,8}
     py311-min
     style
     typing
@@ -25,7 +25,7 @@ commands = pre-commit run --all-files
 [testenv:typing]
 deps = -r requirements/mypy.txt
 commands =
-    mypy --python-version 3.7
+    mypy --python-version 3.8
     mypy --python-version 3.11
 
 [testenv:docs]


### PR DESCRIPTION
This drops support for Python 3.7 which has reached EOL

Checklist:

~- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.~
~- [ ] Add or update relevant docs, in the docs folder and in code.~
- [X] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
~- [ ] Add `.. versionchanged::` entries in any relevant code docs.~
- [X] Run `pre-commit` hooks and fix any issues.
- [X] Run `pytest` and `tox`, no tests failed.
