### PR TITLE
deprecate __version__ attribute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,16 @@
+Version 3.1.1
+-------------
+
+Unreleased
+
+-   Deprecate the ``__version__`` attribute. Use feature detection, or
+    ``importlib.metadata.version("flask-sqlalchemy")``, instead. :issue:`5230`
+
+
 Version 3.1.0
 -------------
 
-Released 2023-09-10
+Released 2023-09-11
 
 -   Drop support for Python 3.7.  :pr:`1251`
 -   Add support for the SQLAlchemy 2.x API via ``model_class`` parameter. :issue:`1140`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name = "Flask-SQLAlchemy"
+version = "3.1.1.dev"
 description = "Add SQLAlchemy support to your Flask application."
 readme = "README.rst"
 license = { file = "LICENSE.rst" }
@@ -18,7 +19,6 @@ dependencies = [
     "flask>=2.2.5",
     "sqlalchemy>=2.0.16",
 ]
-dynamic = ["version"]
 
 [project.urls]
 Donate = "https://palletsprojects.com/donate"

--- a/src/flask_sqlalchemy/__init__.py
+++ b/src/flask_sqlalchemy/__init__.py
@@ -1,9 +1,26 @@
 from __future__ import annotations
 
-from .extension import SQLAlchemy
+import typing as t
 
-__version__ = "3.1.0"
+from .extension import SQLAlchemy
 
 __all__ = [
     "SQLAlchemy",
 ]
+
+
+def __getattr__(name: str) -> t.Any:
+    if name == "__version__":
+        import importlib.metadata
+        import warnings
+
+        warnings.warn(
+            "The '__version__' attribute is deprecated and will be removed in"
+            " Flask-SQLAlchemy 3.2. Use feature detection or"
+            " 'importlib.metadata.version(\"flask-sqlalchemy\")' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return importlib.metadata.version("flask-sqlalchemy")
+
+    raise AttributeError(name)


### PR DESCRIPTION
The `__version__` attribute is an old pattern from early in Python packaging. Setuptools eventually made it easier to use the pattern by allowing reading the value from the attribute at build time, and some other build backends have done the same.

However, there's no reason to expose this directly in code anymore. It's usually easier to use feature detection (`hasattr`, `try/except`) instead. `importlib.metadata.version("flask-sqlalchemy")` can be used to get the version at runtime in a standard way, if it's really needed.