### PR TITLE
Add `paginate_rows()` method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+Version 3.2.0
+-------------
+
+Unreleased
+
+-   Added ``paginate_rows`` method to the extension object for paginating over
+    ``Row`` objects :issue:`1168`:
+
 Version 3.1.1
 -------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -65,7 +65,8 @@ Pagination
     based on the current page and number of items per page.
 
     Don't create pagination objects manually. They are created by
-    :meth:`.SQLAlchemy.paginate` and :meth:`.Query.paginate`.
+    :meth:`.SQLAlchemy.paginate`, :meth:`.SQLAlchemy.paginate_rows`, and
+    :meth:`.Query.paginate`.
 
     .. versionchanged:: 3.0
         Iterating over a pagination object iterates over its items.

--- a/src/flask_sqlalchemy/extension.py
+++ b/src/flask_sqlalchemy/extension.py
@@ -22,6 +22,7 @@ from .model import DefaultMetaNoName
 from .model import Model
 from .model import NameMixin
 from .pagination import Pagination
+from .pagination import RowPagination
 from .pagination import SelectPagination
 from .query import Query
 from .session import _app_ctx_id
@@ -814,7 +815,8 @@ class SQLAlchemy:
 
         The statement should select a model class, like ``select(User)``. This applies
         ``unique()`` and ``scalars()`` modifiers to the result, so compound selects will
-        not return the expected results.
+        not return the expected results.  To paginate a compound select, use
+        :meth:`paginate_rows` instead.
 
         :param select: The ``select`` statement to paginate.
         :param page: The current page, used to calculate the offset. Defaults to the
@@ -837,6 +839,54 @@ class SQLAlchemy:
         .. versionadded:: 3.0
         """
         return SelectPagination(
+            select=select,
+            session=self.session(),
+            page=page,
+            per_page=per_page,
+            max_per_page=max_per_page,
+            error_out=error_out,
+            count=count,
+        )
+
+    def paginate_rows(
+        self,
+        select: sa.sql.Select[t.Any],
+        *,
+        page: int | None = None,
+        per_page: int | None = None,
+        max_per_page: int | None = None,
+        error_out: bool = True,
+        count: bool = True,
+    ) -> Pagination:
+        """Apply an offset and limit to a select statment based on the current page and
+        number of items per page, returning a :class:`.Pagination` object.
+
+        Unlike :meth:`paginate`, the statement may select any number of
+        columns, like ``select(User.name, User.password)``.  Regardless of how
+        many columns are selected, the :attr:`.Pagination.items` attribute of
+        the returned :class:`.Pagination` instance will contain :class:`Row
+        <sqlalchemy.engine.Row>` objects.
+
+        Note that the ``unique()`` modifier is applied to the result.
+
+        :param select: The ``select`` statement to paginate.
+        :param page: The current page, used to calculate the offset. Defaults to the
+            ``page`` query arg during a request, or 1 otherwise.
+        :param per_page: The maximum number of items on a page, used to calculate the
+            offset and limit. Defaults to the ``per_page`` query arg during a request,
+            or 20 otherwise.
+        :param max_per_page: The maximum allowed value for ``per_page``, to limit a
+            user-provided value. Use ``None`` for no limit. Defaults to 100.
+        :param error_out: Abort with a ``404 Not Found`` error if no items are returned
+            and ``page`` is not 1, or if ``page`` or ``per_page`` is less than 1, or if
+            either are not ints.
+        :param count: Calculate the total number of values by issuing an extra count
+            query. For very complex queries this may be inaccurate or slow, so it can be
+            disabled and set manually if necessary.
+
+        .. versionadded:: 3.2
+        """
+        return RowPagination(
             select=select,
             session=self.session(),
             page=page,


### PR DESCRIPTION
This PR adds a `paginate_rows()` method to the extension object that behaves like `paginate()`, except its items are `sqlalchemy.Row` instances instead of whatever was the in the first column of the `select()`.  This makes it possible to paginate compound selects without having to fall back to the legacy `Query` API.

- Fixes #1168.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.