### PR TITLE
Fix PR id in the changelog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Version 3.1.1
 Released 2023-09-11
 
 -   Deprecate the ``__version__`` attribute. Use feature detection, or
-    ``importlib.metadata.version("flask-sqlalchemy")``, instead. :issue:`5230`
+    ``importlib.metadata.version("flask-sqlalchemy")``, instead. :pr:`1256`
 
 
 Version 3.1.0


### PR DESCRIPTION
Hey,

I found a wrong link in the changelog and here is the fix.

You can find the original PR here:
https://github.com/pallets-eco/flask-sqlalchemy/pull/1256

An issue wasn't linked so I changed the link to be redirecting to a PR.

Cheers,
Damian