### PR TITLE
Fixing missing base class in reflection docs, adding to reflection test

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,11 +37,5 @@ jobs:
           python-version: ${{ matrix.python }}
           cache: 'pip'
           cache-dependency-path: 'requirements/*.txt'
-      - name: cache mypy
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
-        with:
-          path: ./.mypy_cache
-          key: mypy|${{ matrix.python }}|${{ hashFiles('requirements/mypy.txt') }}
-        if: matrix.tox == 'typing'
       - run: pip install tox
       - run: tox r -e ${{ matrix.tox }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: ./.mypy_cache
-          key: mypy|${{ matrix.python }}|${{ hashFiles('pyproject.toml') }}
+          key: mypy|${{ matrix.python }}|${{ hashFiles('requirements/mypy.txt') }}
         if: matrix.tox == 'typing'
       - run: pip install tox
       - run: tox r -e ${{ matrix.tox }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,5 +37,11 @@ jobs:
           python-version: ${{ matrix.python }}
           cache: 'pip'
           cache-dependency-path: 'requirements/*.txt'
+      - name: cache mypy
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        with:
+          path: ./.mypy_cache
+          key: mypy|${{ matrix.python }}|${{ hashFiles('pyproject.toml') }}
+        if: matrix.tox == 'typing'
       - run: pip install tox
       - run: tox r -e ${{ matrix.tox }}

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -139,13 +139,18 @@ defining the full model.
 
 Call the :meth:`~.SQLAlchemy.reflect` method on the extension. It will reflect all the
 tables for each bind key. Each metadata's ``tables`` attribute will contain the detected
-table objects.
+table objects. See :doc:`binds` for more details on bind keys.
 
 .. code-block:: python
 
     with app.app_context():
         db.reflect()
 
+    # From the default bind key
+    class Book(db.Model):
+        __table__ = db.metadata.tables["book"]
+
+    # From an "auth" bind key
     class User(db.Model):
         __table__ = db.metadatas["auth"].tables["user"]
 

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -146,7 +146,7 @@ table objects.
     with app.app_context():
         db.reflect()
 
-    class User:
+    class User(db.Model):
         __table__ = db.metadatas["auth"].tables["user"]
 
 In most cases, it will be more maintainable to define the model classes yourself. You

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -166,6 +166,13 @@ def test_reflect(app: Flask) -> None:
     class User(db.Model):
         __table__ = db.metadata.tables["user"]
 
+    class Post(db.Model):
+        __table__ = db.metadatas["post"].tables["post"]
+
     db.session.add(User(id=1))
     users = db.session.execute(sa.select(User)).scalars().all()
     assert len(users) == 1
+
+    db.session.add(Post(id=1))
+    posts = db.session.execute(sa.select(Post)).scalars().all()
+    assert len(posts) == 1

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -162,3 +162,10 @@ def test_reflect(app: Flask) -> None:
     db.reflect()
     assert "user" in db.metadata.tables
     assert "post" in db.metadatas["post"].tables
+
+    class User(db.Model):
+        __table__ = db.metadata.tables["user"]
+
+    db.session.add(User(id=1))
+    users = db.session.execute(sa.select(User)).scalars().all()
+    assert len(users) == 1


### PR DESCRIPTION
This PR adds "(db.Model)" to reflection docs example. I also added to the reflection test to mirror the documentation example, and I put an additional example in the docs showing default bind key. 

- fixes #1280

Checklist:

- [X] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [X] Add or update relevant docs, in the docs folder and in code.
~- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.~
~- [ ] Add `.. versionchanged::` entries in any relevant code docs.~
- [X] Run `pre-commit` hooks and fix any issues.
- [X] Run `pytest` and `tox`, no tests failed.
