### PR TITLE
Fix repr and add tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,11 +37,5 @@ jobs:
           python-version: ${{ matrix.python }}
           cache: 'pip'
           cache-dependency-path: 'requirements/*.txt'
-      - name: cache mypy
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
-        with:
-          path: ./.mypy_cache
-          key: mypy|${{ matrix.python }}|${{ hashFiles('requirements/mypy.txt') }}
-        if: matrix.tox == 'typing'
       - run: pip install tox
       - run: tox r -e ${{ matrix.tox }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,5 +37,11 @@ jobs:
           python-version: ${{ matrix.python }}
           cache: 'pip'
           cache-dependency-path: 'requirements/*.txt'
+      - name: cache mypy
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        with:
+          path: ./.mypy_cache
+          key: mypy|${{ matrix.python }}|${{ hashFiles('requirements/mypy.txt') }}
+        if: matrix.tox == 'typing'
       - run: pip install tox
       - run: tox r -e ${{ matrix.tox }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Version 3.1.2
+-------------
+
+- Fix issue with calling ``repr()`` on ``SQLAlchemy`` instance with no default engine. :issue:`1295`
+
+
 Version 3.1.1
 -------------
 

--- a/src/flask_sqlalchemy/extension.py
+++ b/src/flask_sqlalchemy/extension.py
@@ -281,12 +281,14 @@ class SQLAlchemy:
         if not has_app_context():
             return f"<{type(self).__name__}>"
 
-        message = f"{type(self).__name__} {self.engine.url}"
+        num_default_engines = 1 if self.engines.get(None) else 0
+        engine_str = self.engine.url if num_default_engines else "(No default engine)"
 
-        if len(self.engines) > 1:
-            message = f"{message} +{len(self.engines) - 1}"
+        num_other_engines = len(self.engines) - num_default_engines
+        if num_other_engines >= 1:
+            engine_str = f"{engine_str} +{num_other_engines} engines"
 
-        return f"<{message}>"
+        return f"<{type(self).__name__} {engine_str}>"
 
     def init_app(self, app: Flask) -> None:
         """Initialize a Flask application for use with this extension instance. This

--- a/tests/test_extension_repr.py
+++ b/tests/test_extension_repr.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from flask import Flask
+
+from flask_sqlalchemy import SQLAlchemy
+
+
+def test_repr_no_context() -> None:
+    db = SQLAlchemy()
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
+
+    db.init_app(app)
+    assert repr(db) == "<SQLAlchemy>"
+
+
+def test_repr_default() -> None:
+    db = SQLAlchemy()
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
+
+    db.init_app(app)
+    with app.app_context():
+        assert repr(db) == "<SQLAlchemy sqlite://>"
+
+
+def test_repr_default_plustwo() -> None:
+    db = SQLAlchemy()
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
+    app.config["SQLALCHEMY_BINDS"] = {
+        "a": "sqlite:///:memory:",
+        "b": "sqlite:///test.db",
+    }
+
+    db.init_app(app)
+    with app.app_context():
+        assert repr(db) == "<SQLAlchemy sqlite:// +2 engines>"
+
+
+def test_repr_nodefault() -> None:
+    db = SQLAlchemy()
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_BINDS"] = {"x": "sqlite:///:memory:"}
+
+    db.init_app(app)
+    with app.app_context():
+        assert repr(db) == "<SQLAlchemy (No default engine) +1 engines>"
+
+
+def test_repr_nodefault_plustwo() -> None:
+    db = SQLAlchemy()
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_BINDS"] = {
+        "a": "sqlite:///:memory:",
+        "b": "sqlite:///test.db",
+    }
+
+    db.init_app(app)
+    with app.app_context():
+        assert repr(db) == "<SQLAlchemy (No default engine) +2 engines>"


### PR DESCRIPTION
This PR adds test for SQLAlchemy's repr and fixes its handling of the no default engine scenario. 

This fix assumes we want engine() to continue to throw a KeyError in that scenario (i.e. all handling is in repr itself).

- fixes #1295

Checklist:

- [X] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [X] Add or update relevant docs, in the docs folder and in code.
- [X] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [X] Add `.. versionchanged::` entries in any relevant code docs.
- [X] Run `pre-commit` hooks and fix any issues.
- [X] Run `pytest` and `tox`, no tests failed.
