### PR TITLE
Stop using datetime.utcnow() in tests

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import typing as t
 from datetime import datetime
+from datetime import timezone
 
 import pytest
 import sqlalchemy as sa
@@ -12,6 +13,10 @@ from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_sqlalchemy.model import DefaultMeta
 from flask_sqlalchemy.model import Model
+
+
+def utc_now() -> datetime:
+    return datetime.now(tz=timezone.utc)
 
 
 def test_default_model_class_1x(app: Flask) -> None:
@@ -147,12 +152,12 @@ def test_abstractmodel(app: Flask, model_class: t.Any) -> None:
         class TimestampModel(db.Model):
             __abstract__ = True
             created: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
-                db.DateTime, nullable=False, insert_default=datetime.utcnow, init=False
+                db.DateTime, nullable=False, insert_default=utc_now, init=False
             )
             updated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
                 db.DateTime,
-                insert_default=datetime.utcnow,
-                onupdate=datetime.utcnow,
+                insert_default=utc_now,
+                onupdate=utc_now,
                 init=False,
             )
 
@@ -167,10 +172,10 @@ def test_abstractmodel(app: Flask, model_class: t.Any) -> None:
         class TimestampModel(db.Model):  # type: ignore[no-redef]
             __abstract__ = True
             created: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
-                db.DateTime, nullable=False, default=datetime.utcnow
+                db.DateTime, nullable=False, default=utc_now
             )
             updated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
-                db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+                db.DateTime, default=utc_now, onupdate=utc_now
             )
 
         class Post(TimestampModel):  # type: ignore[no-redef]
@@ -181,10 +186,8 @@ def test_abstractmodel(app: Flask, model_class: t.Any) -> None:
 
         class TimestampModel(db.Model):  # type: ignore[no-redef]
             __abstract__ = True
-            created = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
-            updated = db.Column(
-                db.DateTime, onupdate=datetime.utcnow, default=datetime.utcnow
-            )
+            created = db.Column(db.DateTime, nullable=False, default=utc_now)
+            updated = db.Column(db.DateTime, onupdate=utc_now, default=utc_now)
 
         class Post(TimestampModel):  # type: ignore[no-redef]
             id = db.Column(db.Integer, primary_key=True)
@@ -207,12 +210,12 @@ def test_mixinmodel(app: Flask, model_class: t.Any) -> None:
 
         class TimestampMixin(sa_orm.MappedAsDataclass):
             created: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
-                db.DateTime, nullable=False, insert_default=datetime.utcnow, init=False
+                db.DateTime, nullable=False, insert_default=utc_now, init=False
             )
             updated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
                 db.DateTime,
-                insert_default=datetime.utcnow,
-                onupdate=datetime.utcnow,
+                insert_default=utc_now,
+                onupdate=utc_now,
                 init=False,
             )
 
@@ -226,10 +229,10 @@ def test_mixinmodel(app: Flask, model_class: t.Any) -> None:
 
         class TimestampMixin:  # type: ignore[no-redef]
             created: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
-                db.DateTime, nullable=False, default=datetime.utcnow
+                db.DateTime, nullable=False, default=utc_now
             )
             updated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
-                db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+                db.DateTime, default=utc_now, onupdate=utc_now
             )
 
         class Post(TimestampMixin, db.Model):  # type: ignore[no-redef]
@@ -239,10 +242,8 @@ def test_mixinmodel(app: Flask, model_class: t.Any) -> None:
     else:
 
         class TimestampMixin:  # type: ignore[no-redef]
-            created = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
-            updated = db.Column(
-                db.DateTime, onupdate=datetime.utcnow, default=datetime.utcnow
-            )
+            created = db.Column(db.DateTime, nullable=False, default=utc_now)
+            updated = db.Column(db.DateTime, onupdate=utc_now, default=utc_now)
 
         class Post(TimestampMixin, db.Model):  # type: ignore[no-redef]
             id = db.Column(db.Integer, primary_key=True)


### PR DESCRIPTION
datetime.utcnow() is deprecated for Python 3.12+, and raises a warning. Since warnings are treated as errors, this results in test failures. Since utcnow calls are done by the SQLAlchemy mapping machinery, we need to use a callable.

Fixes #1303

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
