### PR TITLE
Fix issue #1318: Type (typehint) error for `db.relationship`

### DIFF
--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -19,7 +19,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@be8aa5be94131386884a6da4189effda9b14aa21
+      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771
         with:
           issue-inactive-days: 14
           pr-inactive-days: 14

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,7 @@ jobs:
     outputs:
       hash: ${{ steps.hash.outputs.hash }}
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
         with:
           python-version: '3.x'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,7 @@ jobs:
     outputs:
       hash: ${{ steps.hash.outputs.hash }}
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
       - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
         with:
           python-version: '3.x'
@@ -23,7 +23,7 @@ jobs:
       - name: generate hash
         id: hash
         run: cd dist && echo "hash=$(sha256sum * | base64 -w0)" >> $GITHUB_OUTPUT
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
         with:
           path: ./dist
   provenance:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,8 +9,8 @@ jobs:
     outputs:
       hash: ${{ steps.hash.outputs.hash }}
     steps:
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
-      - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236
         with:
           python-version: '3.x'
           cache: 'pip'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -63,10 +63,10 @@ jobs:
     steps:
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
       # Try uploading to Test PyPI first, in case something fails.
-      - uses: pypa/gh-action-pypi-publish@b7f401de30cb6434a1e19f805ff006643653240e
+      - uses: pypa/gh-action-pypi-publish@2f6f737ca5f74c637829c0f5c3acd0e29ea5e8bf
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: artifact/
-      - uses: pypa/gh-action-pypi-publish@b7f401de30cb6434a1e19f805ff006643653240e
+      - uses: pypa/gh-action-pypi-publish@2f6f737ca5f74c637829c0f5c3acd0e29ea5e8bf
         with:
           packages-dir: artifact/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,7 @@ jobs:
           - {name: '3.8', python: '3.8', tox: py38}
           - {name: 'Typing', python: '3.11', tox: typing}
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
         with:
           python-version: ${{ matrix.python }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,14 +31,14 @@ jobs:
           - {name: '3.8', python: '3.8', tox: py38}
           - {name: 'Typing', python: '3.11', tox: typing}
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
       - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
         with:
           python-version: ${{ matrix.python }}
           cache: 'pip'
           cache-dependency-path: 'requirements/*.txt'
       - name: cache mypy
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
         with:
           path: ./.mypy_cache
           key: mypy|${{ matrix.python }}|${{ hashFiles('requirements/mypy.txt') }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,8 +31,8 @@ jobs:
           - {name: '3.8', python: '3.8', tox: py38}
           - {name: 'Typing', python: '3.11', tox: typing}
     steps:
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
-      - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236
         with:
           python-version: ${{ matrix.python }}
           cache: 'pip'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,18 +2,18 @@ ci:
   autoupdate_schedule: monthly
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.10.1
+    rev: v3.14.0
     hooks:
       - id: pyupgrade
         args: ["--py38-plus"]
   - repo: https://github.com/asottile/reorder-python-imports
-    rev: v3.10.0
+    rev: v3.12.0
     hooks:
       - id: reorder-python-imports
         files: "^(?!examples/)"
         args: ["--py38-plus", "--application-directories", "src"]
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.9.1
     hooks:
       - id: black
         args: ["--target-version", "py38"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         files: "^(?!examples/)"
         args: ["--py38-plus", "--application-directories", "src"]
   - repo: https://github.com/psf/black
-    rev: 23.11.0
+    rev: 23.12.1
     hooks:
       - id: black
         args: ["--target-version", "py38"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ ci:
   autoupdate_schedule: monthly
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.14.0
+    rev: v3.15.0
     hooks:
       - id: pyupgrade
         args: ["--py38-plus"]
@@ -13,7 +13,7 @@ repos:
         files: "^(?!examples/)"
         args: ["--py38-plus", "--application-directories", "src"]
   - repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 23.11.0
     hooks:
       - id: black
         args: ["--target-version", "py38"]
@@ -25,7 +25,7 @@ repos:
           - flake8-bugbear
           - flake8-implicit-str-concat
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: fix-byte-order-marker
       - id: trailing-whitespace

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Version 3.1.2
+-------------
+
+- Fix issue with calling ``repr()`` on ``SQLAlchemy`` instance with no default engine. :issue:`1295`
+
+
 Version 3.1.1
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Version 3.1.1
 Released 2023-09-11
 
 -   Deprecate the ``__version__`` attribute. Use feature detection, or
-    ``importlib.metadata.version("flask-sqlalchemy")``, instead. :issue:`5230`
+    ``importlib.metadata.version("flask-sqlalchemy")``, instead. :pr:`1256`
 
 
 Version 3.1.0

--- a/README.rst
+++ b/README.rst
@@ -40,8 +40,8 @@ A Simple Example
     db = SQLAlchemy(app, model_class=Base)
 
     class User(db.Model):
-        id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
-        username: Mapped[str] = mapped_column(db.String, unique=True, nullable=False)
+        id: Mapped[int] = mapped_column(primary_key=True)
+        username: Mapped[str] = mapped_column(unique=True)
 
     with app.app_context():
         db.create_all()

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -37,10 +37,10 @@ joined-table inheritance.
     db = SQLAlchemy(app, model_class=Base)
 
     class User(db.Model):
-        name: Mapped[str] = mapped_column(String)
+        name: Mapped[str]
 
     class Employee(User):
-        title: Mapped[str] = mapped_column(String)
+        title: Mapped[str]
 
 
 Abstract Models and Mixins
@@ -52,34 +52,33 @@ they are created or updated.
 
 .. code-block:: python
 
-    from datetime import datetime
-    from sqlalchemy import DateTime, Integer, String
-    from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, declared_attr
+    from datetime import datetime, timezone
+    from sqlalchemy.orm import Mapped, mapped_column
 
     class TimestampModel(db.Model):
         __abstract__ = True
-        created: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
-        updated: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+        created: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc))
+        updated: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
     class Author(db.Model):
-        id: Mapped[int] = mapped_column(Integer, primary_key=True)
-        username: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+        id: Mapped[int] = mapped_column(primary_key=True)
+        username: Mapped[str] = mapped_column(unique=True)
 
     class Post(TimestampModel):
-        id: Mapped[int] = mapped_column(Integer, primary_key=True)
-        title: Mapped[str] = mapped_column(String, nullable=False)
+        id: Mapped[int] = mapped_column(primary_key=True)
+        title: Mapped[str]
 
 This can also be done with a mixin class, inheriting from ``db.Model`` separately.
 
 .. code-block:: python
 
     class TimestampMixin:
-        created: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
-        updated: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+        created: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc))
+        updated: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
     class Post(TimestampMixin, db.Model):
-        id: Mapped[int] = mapped_column(Integer, primary_key=True)
-        title: Mapped[str] = mapped_column(String, nullable=False)
+        id: Mapped[int] = mapped_column(primary_key=True)
+        title: Mapped[str]
 
 
 Disabling Table Name Generation

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -86,9 +86,9 @@ is not set and a primary key column is defined.
     from sqlalchemy.orm import Mapped, mapped_column
 
     class User(db.Model):
-        id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
-        username: Mapped[str] = mapped_column(db.String, unique=True, nullable=False)
-        email: Mapped[str] = mapped_column(db.String)
+        id: Mapped[int] = mapped_column(primary_key=True)
+        username: Mapped[str] = mapped_column(unique=True)
+        email: Mapped[str]
 
 
 Defining a model does not create it in the database. Use :meth:`~.SQLAlchemy.create_all`

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -139,14 +139,19 @@ defining the full model.
 
 Call the :meth:`~.SQLAlchemy.reflect` method on the extension. It will reflect all the
 tables for each bind key. Each metadata's ``tables`` attribute will contain the detected
-table objects.
+table objects. See :doc:`binds` for more details on bind keys.
 
 .. code-block:: python
 
     with app.app_context():
         db.reflect()
 
-    class User:
+    # From the default bind key
+    class Book(db.Model):
+        __table__ = db.metadata.tables["book"]
+
+    # From an "auth" bind key
+    class User(db.Model):
         __table__ = db.metadatas["auth"].tables["user"]
 
 In most cases, it will be more maintainable to define the model classes yourself. You

--- a/docs/pagination.rst
+++ b/docs/pagination.rst
@@ -58,7 +58,7 @@ The following Jinja macro renders a simple pagination widget.
 .. code-block:: jinja
 
     {% macro render_pagination(pagination, endpoint) %}
-      <div class=page-items>
+      <div class="page-items">
         {{ pagination.first }} - {{ pagination.last }} of {{ pagination.total }}
       </div>
       <div class=pagination>

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -115,9 +115,9 @@ The model will generate a table name by converting the ``CamelCase`` class name 
     from sqlalchemy.orm import Mapped, mapped_column
 
     class User(db.Model):
-        id: Mapped[int] = mapped_column(Integer, primary_key=True)
-        username: Mapped[str] = mapped_column(String, unique=True, nullable=False)
-        email: Mapped[str] = mapped_column(String)
+        id: Mapped[int] = mapped_column(primary_key=True)
+        username: Mapped[str] = mapped_column(unique=True)
+        email: Mapped[str]
 
 
 See :doc:`models` for more information about defining and creating models and tables.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -48,7 +48,7 @@ imagesize==1.4.1
     # via sphinx
 iniconfig==2.0.0
     # via pytest
-jinja2==3.1.2
+jinja2==3.1.3
     # via sphinx
 markupsafe==2.1.3
     # via jinja2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ alabaster==0.7.13
     # via sphinx
 babel==2.12.1
     # via sphinx
-blinker==1.6.2
+blinker==1.6.3
     # via -r tests.in
 build==1.0.3
     # via pip-tools
@@ -52,7 +52,7 @@ jinja2==3.1.2
     # via sphinx
 markupsafe==2.1.3
     # via jinja2
-mypy==1.5.1
+mypy==1.6.1
     # via -r mypy.in
 mypy-extensions==1.0.0
     # via mypy
@@ -78,7 +78,7 @@ pluggy==1.3.0
     # via
     #   pytest
     #   tox
-pre-commit==3.4.0
+pre-commit==3.5.0
     # via -r dev.in
 pygments==2.16.1
     # via sphinx
@@ -86,7 +86,7 @@ pyproject-api==1.6.1
     # via tox
 pyproject-hooks==1.0.0
     # via build
-pytest==7.4.2
+pytest==7.4.3
     # via
     #   -r mypy.in
     #   -r tests.in
@@ -126,7 +126,7 @@ sphinxcontrib-qthelp==1.0.6
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.9
     # via sphinx
-sqlalchemy==2.0.21
+sqlalchemy==2.0.22
     # via -r mypy.in
 tox==4.11.3
     # via -r dev.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,7 +12,7 @@ blinker==1.7.0
     # via -r tests.in
 build==1.0.3
     # via pip-tools
-cachetools==5.3.1
+cachetools==5.3.2
     # via tox
 certifi==2023.7.22
     # via requests
@@ -34,7 +34,7 @@ distlib==0.3.7
     # via virtualenv
 docutils==0.20.1
     # via sphinx
-filelock==3.12.3
+filelock==3.13.1
     # via
     #   tox
     #   virtualenv
@@ -52,13 +52,13 @@ jinja2==3.1.3
     # via sphinx
 markupsafe==2.1.3
     # via jinja2
-mypy==1.7.1
+mypy==1.8.0
     # via -r mypy.in
 mypy-extensions==1.0.0
     # via mypy
 nodeenv==1.8.0
     # via pre-commit
-packaging==23.1
+packaging==23.2
     # via
     #   build
     #   pallets-sphinx-themes
@@ -70,7 +70,7 @@ pallets-sphinx-themes==2.1.1
     # via -r docs.in
 pip-tools==7.3.0
     # via -r dev.in
-platformdirs==3.10.0
+platformdirs==4.1.0
     # via
     #   tox
     #   virtualenv
@@ -78,7 +78,7 @@ pluggy==1.3.0
     # via
     #   pytest
     #   tox
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r dev.in
 pygments==2.16.1
     # via sphinx
@@ -86,7 +86,7 @@ pyproject-api==1.6.1
     # via tox
 pyproject-hooks==1.0.0
     # via build
-pytest==7.4.3
+pytest==7.4.4
     # via
     #   -r mypy.in
     #   -r tests.in
@@ -126,9 +126,9 @@ sphinxcontrib-qthelp==1.0.6
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.9
     # via sphinx
-sqlalchemy==2.0.23
+sqlalchemy==2.0.25
     # via -r mypy.in
-tox==4.11.4
+tox==4.12.0
     # via -r dev.in
 typing-extensions==4.7.1
     # via
@@ -136,7 +136,7 @@ typing-extensions==4.7.1
     #   sqlalchemy
 urllib3==2.0.7
     # via requests
-virtualenv==20.24.5
+virtualenv==20.25.0
     # via
     #   pre-commit
     #   tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -134,7 +134,7 @@ typing-extensions==4.7.1
     # via
     #   mypy
     #   sqlalchemy
-urllib3==2.0.6
+urllib3==2.0.7
     # via requests
 virtualenv==20.24.5
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ alabaster==0.7.13
     # via sphinx
 babel==2.12.1
     # via sphinx
-blinker==1.6.3
+blinker==1.7.0
     # via -r tests.in
 build==1.0.3
     # via pip-tools
@@ -52,7 +52,7 @@ jinja2==3.1.2
     # via sphinx
 markupsafe==2.1.3
     # via jinja2
-mypy==1.6.1
+mypy==1.7.1
     # via -r mypy.in
 mypy-extensions==1.0.0
     # via mypy
@@ -126,9 +126,9 @@ sphinxcontrib-qthelp==1.0.6
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.9
     # via sphinx
-sqlalchemy==2.0.22
+sqlalchemy==2.0.23
     # via -r mypy.in
-tox==4.11.3
+tox==4.11.4
     # via -r dev.in
 typing-extensions==4.7.1
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -134,7 +134,7 @@ typing-extensions==4.7.1
     # via
     #   mypy
     #   sqlalchemy
-urllib3==2.0.4
+urllib3==2.0.6
     # via requests
 virtualenv==20.24.5
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -99,7 +99,7 @@ requests==2.31.0
     # via sphinx
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==7.2.5
+sphinx==7.2.6
     # via
     #   -r docs.in
     #   pallets-sphinx-themes
@@ -126,7 +126,7 @@ sphinxcontrib-qthelp==1.0.6
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.9
     # via sphinx
-sqlalchemy==2.0.20
+sqlalchemy==2.0.21
     # via -r mypy.in
 tox==4.11.3
     # via -r dev.in

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -18,7 +18,7 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-jinja2==3.1.2
+jinja2==3.1.3
     # via sphinx
 markupsafe==2.1.3
     # via jinja2

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -34,7 +34,7 @@ requests==2.31.0
     # via sphinx
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==7.2.5
+sphinx==7.2.6
     # via
     #   -r docs.in
     #   pallets-sphinx-themes

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -61,5 +61,5 @@ sphinxcontrib-qthelp==1.0.6
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.9
     # via sphinx
-urllib3==2.0.4
+urllib3==2.0.6
     # via requests

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -61,5 +61,5 @@ sphinxcontrib-qthelp==1.0.6
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.9
     # via sphinx
-urllib3==2.0.6
+urllib3==2.0.7
     # via requests

--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -8,7 +8,7 @@ greenlet==2.0.2
     # via sqlalchemy
 iniconfig==2.0.0
     # via pytest
-mypy==1.6.1
+mypy==1.7.1
     # via -r mypy.in
 mypy-extensions==1.0.0
     # via mypy
@@ -18,7 +18,7 @@ pluggy==1.3.0
     # via pytest
 pytest==7.4.3
     # via -r mypy.in
-sqlalchemy==2.0.22
+sqlalchemy==2.0.23
     # via -r mypy.in
 typing-extensions==4.7.1
     # via

--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -18,7 +18,7 @@ pluggy==1.3.0
     # via pytest
 pytest==7.4.2
     # via -r mypy.in
-sqlalchemy==2.0.20
+sqlalchemy==2.0.21
     # via -r mypy.in
 typing-extensions==4.7.1
     # via

--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -8,7 +8,7 @@ greenlet==2.0.2
     # via sqlalchemy
 iniconfig==2.0.0
     # via pytest
-mypy==1.7.1
+mypy==1.8.0
     # via -r mypy.in
 mypy-extensions==1.0.0
     # via mypy
@@ -16,9 +16,9 @@ packaging==23.1
     # via pytest
 pluggy==1.3.0
     # via pytest
-pytest==7.4.3
+pytest==7.4.4
     # via -r mypy.in
-sqlalchemy==2.0.23
+sqlalchemy==2.0.25
     # via -r mypy.in
 typing-extensions==4.7.1
     # via

--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -8,7 +8,7 @@ greenlet==2.0.2
     # via sqlalchemy
 iniconfig==2.0.0
     # via pytest
-mypy==1.5.1
+mypy==1.6.1
     # via -r mypy.in
 mypy-extensions==1.0.0
     # via mypy
@@ -16,9 +16,9 @@ packaging==23.1
     # via pytest
 pluggy==1.3.0
     # via pytest
-pytest==7.4.2
+pytest==7.4.3
     # via -r mypy.in
-sqlalchemy==2.0.21
+sqlalchemy==2.0.22
     # via -r mypy.in
 typing-extensions==4.7.1
     # via

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile tests.in
 #
-blinker==1.6.2
+blinker==1.6.3
     # via -r tests.in
-coverage[toml]==7.3.1
+coverage[toml]==7.3.2
     # via
     #   -r tests.in
     #   pytest-cov
@@ -16,7 +16,7 @@ packaging==23.1
     # via pytest
 pluggy==1.3.0
     # via pytest
-pytest==7.4.2
+pytest==7.4.3
     # via
     #   -r tests.in
     #   pytest-cov

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -6,10 +6,9 @@
 #
 blinker==1.7.0
     # via -r tests.in
-coverage[toml]==7.3.2
+coverage[toml]==7.4.0
     # via
     #   -r tests.in
-    #   coverage
     #   pytest-cov
 iniconfig==2.0.0
     # via pytest
@@ -17,7 +16,7 @@ packaging==23.1
     # via pytest
 pluggy==1.3.0
     # via pytest
-pytest==7.4.3
+pytest==7.4.4
     # via
     #   -r tests.in
     #   pytest-cov

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,11 +4,12 @@
 #
 #    pip-compile tests.in
 #
-blinker==1.6.3
+blinker==1.7.0
     # via -r tests.in
 coverage[toml]==7.3.2
     # via
     #   -r tests.in
+    #   coverage
     #   pytest-cov
 iniconfig==2.0.0
     # via pytest

--- a/src/flask_sqlalchemy/extension.py
+++ b/src/flask_sqlalchemy/extension.py
@@ -952,9 +952,7 @@ class SQLAlchemy:
 
             backref[1].setdefault("query_class", self.Query)
 
-    def relationship(
-        self, *args: t.Any, **kwargs: t.Any
-    ) -> sa_orm.Relationship[t.Any]:
+    def relationship(self, *args: t.Any, **kwargs: t.Any) -> sa_orm.Relationship[t.Any]:
         """A :func:`sqlalchemy.orm.relationship` that applies this extension's
         :attr:`Query` class for dynamic relationships and backrefs.
 
@@ -976,9 +974,7 @@ class SQLAlchemy:
         self._set_rel_query(kwargs)
         return sa_orm.dynamic_loader(argument, **kwargs)
 
-    def _relation(
-        self, *args: t.Any, **kwargs: t.Any
-    ) -> sa_orm.Relationship[t.Any]:
+    def _relation(self, *args: t.Any, **kwargs: t.Any) -> sa_orm.Relationship[t.Any]:
         """A :func:`sqlalchemy.orm.relationship` that applies this extension's
         :attr:`Query` class for dynamic relationships and backrefs.
 

--- a/src/flask_sqlalchemy/extension.py
+++ b/src/flask_sqlalchemy/extension.py
@@ -954,7 +954,7 @@ class SQLAlchemy:
 
     def relationship(
         self, *args: t.Any, **kwargs: t.Any
-    ) -> sa_orm.RelationshipProperty[t.Any]:
+    ) -> sa_orm.Relationship[t.Any]:
         """A :func:`sqlalchemy.orm.relationship` that applies this extension's
         :attr:`Query` class for dynamic relationships and backrefs.
 
@@ -978,7 +978,7 @@ class SQLAlchemy:
 
     def _relation(
         self, *args: t.Any, **kwargs: t.Any
-    ) -> sa_orm.RelationshipProperty[t.Any]:
+    ) -> sa_orm.Relationship[t.Any]:
         """A :func:`sqlalchemy.orm.relationship` that applies this extension's
         :attr:`Query` class for dynamic relationships and backrefs.
 

--- a/src/flask_sqlalchemy/extension.py
+++ b/src/flask_sqlalchemy/extension.py
@@ -281,12 +281,14 @@ class SQLAlchemy:
         if not has_app_context():
             return f"<{type(self).__name__}>"
 
-        message = f"{type(self).__name__} {self.engine.url}"
+        num_default_engines = 1 if self.engines.get(None) else 0
+        engine_str = self.engine.url if num_default_engines else "(No default engine)"
 
-        if len(self.engines) > 1:
-            message = f"{message} +{len(self.engines) - 1}"
+        num_other_engines = len(self.engines) - num_default_engines
+        if num_other_engines >= 1:
+            engine_str = f"{engine_str} +{num_other_engines} engines"
 
-        return f"<{message}>"
+        return f"<{type(self).__name__} {engine_str}>"
 
     def init_app(self, app: Flask) -> None:
         """Initialize a Flask application for use with this extension instance. This

--- a/src/flask_sqlalchemy/model.py
+++ b/src/flask_sqlalchemy/model.py
@@ -19,9 +19,7 @@ class _QueryProperty:
     """
 
     def __get__(self, obj: Model | None, cls: type[Model]) -> Query:
-        return cls.query_class(
-            cls, session=cls.__fsa__.session()  # type: ignore[arg-type]
-        )
+        return cls.query_class(cls, session=cls.__fsa__.session())
 
 
 class Model:

--- a/tests/test_extension_repr.py
+++ b/tests/test_extension_repr.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from flask import Flask
+
+from flask_sqlalchemy import SQLAlchemy
+
+
+def test_repr_no_context() -> None:
+    db = SQLAlchemy()
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
+
+    db.init_app(app)
+    assert repr(db) == "<SQLAlchemy>"
+
+
+def test_repr_default() -> None:
+    db = SQLAlchemy()
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
+
+    db.init_app(app)
+    with app.app_context():
+        assert repr(db) == "<SQLAlchemy sqlite://>"
+
+
+def test_repr_default_plustwo() -> None:
+    db = SQLAlchemy()
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
+    app.config["SQLALCHEMY_BINDS"] = {
+        "a": "sqlite:///:memory:",
+        "b": "sqlite:///test.db",
+    }
+
+    db.init_app(app)
+    with app.app_context():
+        assert repr(db) == "<SQLAlchemy sqlite:// +2 engines>"
+
+
+def test_repr_nodefault() -> None:
+    db = SQLAlchemy()
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_BINDS"] = {"x": "sqlite:///:memory:"}
+
+    db.init_app(app)
+    with app.app_context():
+        assert repr(db) == "<SQLAlchemy (No default engine) +1 engines>"
+
+
+def test_repr_nodefault_plustwo() -> None:
+    db = SQLAlchemy()
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_BINDS"] = {
+        "a": "sqlite:///:memory:",
+        "b": "sqlite:///test.db",
+    }
+
+    db.init_app(app)
+    with app.app_context():
+        assert repr(db) == "<SQLAlchemy (No default engine) +2 engines>"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -162,3 +162,17 @@ def test_reflect(app: Flask) -> None:
     db.reflect()
     assert "user" in db.metadata.tables
     assert "post" in db.metadatas["post"].tables
+
+    class User(db.Model):
+        __table__ = db.metadata.tables["user"]
+
+    class Post(db.Model):
+        __table__ = db.metadatas["post"].tables["post"]
+
+    db.session.add(User(id=1))
+    users = db.session.execute(sa.select(User)).scalars().all()
+    assert len(users) == 1
+
+    db.session.add(Post(id=1))
+    posts = db.session.execute(sa.select(Post)).scalars().all()
+    assert len(posts) == 1

--- a/tox.ini
+++ b/tox.ini
@@ -20,11 +20,13 @@ deps =
 commands = pytest -v --tb=short --basetemp={envtmpdir} {posargs}
 
 [testenv:style]
+allowlist_externals = mypy
 deps = pre-commit
 skip_install = true
 commands = pre-commit run --all-files
 
 [testenv:typing]
+allowlist_externals = mypy
 deps = -r requirements/mypy.txt
 commands =
     mypy --python-version 3.8


### PR DESCRIPTION
Fix the typehint inconsistence of `db.relationship(...)`.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #1318
- Fix an issue when tox p fails because mypy is forbidden
   - This issue may be caused by upgrade of `tox`. My `tox` version is `4.12.0`.
   - See details here: https://stackoverflow.com/a/47716994/8266012

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
  - Only bug fixing. No need to do this.
- [ ] Add or update relevant docs, in the docs folder and in code.
  - Only bug fixing. No need to do this.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
  - Only bug fixing. No need to do this.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
