### PR TITLE
Fix issue #1318: Type (typehint) error for `db.relationship`

### DIFF
--- a/src/flask_sqlalchemy/extension.py
+++ b/src/flask_sqlalchemy/extension.py
@@ -952,9 +952,7 @@ class SQLAlchemy:
 
             backref[1].setdefault("query_class", self.Query)
 
-    def relationship(
-        self, *args: t.Any, **kwargs: t.Any
-    ) -> sa_orm.RelationshipProperty[t.Any]:
+    def relationship(self, *args: t.Any, **kwargs: t.Any) -> sa_orm.Relationship[t.Any]:
         """A :func:`sqlalchemy.orm.relationship` that applies this extension's
         :attr:`Query` class for dynamic relationships and backrefs.
 
@@ -976,9 +974,7 @@ class SQLAlchemy:
         self._set_rel_query(kwargs)
         return sa_orm.dynamic_loader(argument, **kwargs)
 
-    def _relation(
-        self, *args: t.Any, **kwargs: t.Any
-    ) -> sa_orm.RelationshipProperty[t.Any]:
+    def _relation(self, *args: t.Any, **kwargs: t.Any) -> sa_orm.Relationship[t.Any]:
         """A :func:`sqlalchemy.orm.relationship` that applies this extension's
         :attr:`Query` class for dynamic relationships and backrefs.
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,12 +23,14 @@ commands = pytest -v --tb=short --basetemp={envtmpdir} {posargs}
 deps = pre-commit
 skip_install = true
 commands = pre-commit run --all-files
+allowlist_externals = mypy
 
 [testenv:typing]
 deps = -r requirements/mypy.txt
 commands =
     mypy --python-version 3.8
     mypy --python-version 3.11
+allowlist_externals = mypy
 
 [testenv:docs]
 deps = -r requirements/docs.txt


### PR DESCRIPTION
Fix the typehint inconsistence of `db.relationship(...)`.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

Rebased on the branch [`3.1.x`](https://github.com/pallets-eco/flask-sqlalchemy/tree/3.1.x).

- fixes #1318
- Fix an issue when tox p fails because mypy is forbidden
   - This issue may be caused by upgrade of `tox>=4`. My `tox` version is `4.12.0`.
   - See details here: https://stackoverflow.com/a/47716994/8266012

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
  - Only bug fixing. No need to do this.
- [ ] Add or update relevant docs, in the docs folder and in code.
  - Only bug fixing. No need to do this.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
  - Only bug fixing. No need to add any change logs for users.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
  - Only bug fixing. No need to do this.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
