### PR TITLE
Fix issue 1312

### DIFF
--- a/src/flask_sqlalchemy/extension.py
+++ b/src/flask_sqlalchemy/extension.py
@@ -10,10 +10,12 @@ import sqlalchemy as sa
 import sqlalchemy.event as sa_event
 import sqlalchemy.exc as sa_exc
 import sqlalchemy.orm as sa_orm
+import typing_extensions as te
 from flask import abort
 from flask import current_app
 from flask import Flask
 from flask import has_app_context
+from sqlalchemy.util import typing as compat_typing
 
 from .model import _QueryProperty
 from .model import BindMixin
@@ -32,20 +34,130 @@ _O = t.TypeVar("_O", bound=object)  # Based on sqlalchemy.orm._typing.py
 
 
 # Type accepted for model_class argument
-_FSA_MCT = t.TypeVar(
-    "_FSA_MCT",
-    bound=t.Union[
-        t.Type[Model],
-        sa_orm.DeclarativeMeta,
-        t.Type[sa_orm.DeclarativeBase],
-        t.Type[sa_orm.DeclarativeBaseNoMeta],
-    ],
-)
+_FSA_MCT = t.Union[
+    t.Type[Model],
+    sa_orm.DeclarativeMeta,
+    t.Type[sa_orm.DeclarativeBase],
+    t.Type[sa_orm.DeclarativeBaseNoMeta],
+    t.Type[sa_orm.MappedAsDataclass],
+]
+_FSA_MCT_T = t.TypeVar("_FSA_MCT_T", bound=_FSA_MCT, covariant=True)
 
 
 # Type returned by make_declarative_base
 class _FSAModel(Model):
     metadata: sa.MetaData
+
+
+if t.TYPE_CHECKING:
+
+    class _FSAModel_KW(_FSAModel):
+        def __init__(self, **kw: t.Any) -> None:
+            ...
+
+else:
+    # To minimize side effects, the type hint only works for static type checker.
+    # At run time, `_FSAModel_KW` falls back to `_FSAModel`
+    _FSAModel_KW = _FSAModel
+
+
+if t.TYPE_CHECKING:
+
+    @compat_typing.dataclass_transform(
+        field_specifiers=(
+            sa_orm.MappedColumn,
+            sa_orm.RelationshipProperty,
+            sa_orm.Composite,
+            sa_orm.Synonym,
+            sa_orm.mapped_column,
+            sa_orm.relationship,
+            sa_orm.composite,
+            sa_orm.synonym,
+            sa_orm.deferred,
+        ),
+    )
+    class _FSAModel_DataClass(_FSAModel):
+        ...
+
+else:
+    # To minimize side effects, the type hint only works for static type checker.
+    # At run time, `_FSAModel_DataClass` falls back to `_FSAModel`
+    _FSAModel_DataClass = _FSAModel
+
+
+class ModelGetter:
+    """Model getter for the ``SQLAlchemy().Model`` property.
+
+    This getter is used for determining the correct type of ``SQLAlchemy().Model``.
+
+    When ``SQLAlchemy`` is initialized by
+
+    .. code-block:: python
+
+        db = SQLAlchemy(model_class=MappedAsDataclass)
+
+    the ``db.Model`` property needs to be a class decorated by ``dataclass_transform``.
+
+    Otherwise, the ``db.Model`` property needs to provide a synthesized initialization
+    method accepting unknown keyword arguments. These keyword arguments are not
+    annotated but limited in the range of data items. This rule is guaranteed by the
+    featuers of all other candidates of ``model_class``.
+
+    Calling the class property ``SQLAlchemy.Model`` will return this descriptor
+    directly.
+    """
+
+    # This variant is at first. Its priority is highest for making SQLAlchemy[Any]
+    # exports a Model with type[_FSAModel_KW].
+    # Note that in actual using cases, users do not need to inherit Model classes.
+    @te.overload
+    def __get__(
+        self, obj: SQLAlchemy[t.Type[Model]], obj_cls: t.Any = None
+    ) -> t.Type[_FSAModel_KW]:
+        ...
+
+    # This variant needs to be prior than DeclarativeBase, because a class may inherit
+    # multiple classes. When both MappedAsDataclass and DeclarativeBase are in the MRO
+    # list, this configuration make type[_FSAModel_DataClass] preferred.
+    @te.overload
+    def __get__(
+        self, obj: SQLAlchemy[t.Type[sa_orm.MappedAsDataclass]], obj_cls: t.Any = None
+    ) -> t.Type[_FSAModel_DataClass]:
+        ...
+
+    @te.overload
+    def __get__(
+        self, obj: SQLAlchemy[t.Type[sa_orm.DeclarativeBase]], obj_cls: t.Any = None
+    ) -> t.Type[_FSAModel_KW]:
+        ...
+
+    @te.overload
+    def __get__(
+        self,
+        obj: SQLAlchemy[t.Type[sa_orm.DeclarativeBaseNoMeta]],
+        obj_cls: t.Any = None,
+    ) -> t.Type[_FSAModel_KW]:
+        ...
+
+    @te.overload
+    def __get__(
+        self, obj: SQLAlchemy[sa_orm.DeclarativeMeta], obj_cls: t.Any = None
+    ) -> t.Type[_FSAModel_KW]:
+        ...
+
+    @te.overload
+    def __get__(
+        self: te.Self, obj: None, obj_cls: t.Optional[t.Type[SQLAlchemy[t.Any]]] = None
+    ) -> t.Type[_FSAModel]:
+        ...
+
+    def __get__(
+        self: te.Self, obj: t.Optional[SQLAlchemy[t.Any]], obj_cls: t.Any = None
+    ) -> t.Union[te.Self, t.Type[Model], t.Type[t.Any]]:
+        if isinstance(obj, SQLAlchemy):
+            return obj._Model
+        else:
+            return self
 
 
 def _get_2x_declarative_bases(
@@ -58,7 +170,7 @@ def _get_2x_declarative_bases(
     ]
 
 
-class SQLAlchemy:
+class SQLAlchemy(t.Generic[_FSA_MCT_T]):
     """Integrates SQLAlchemy with Flask. This handles setting up one or more engines,
     associating tables and models with specific engines, and cleaning up connections and
     sessions after each request.
@@ -168,7 +280,7 @@ class SQLAlchemy:
         metadata: sa.MetaData | None = None,
         session_options: dict[str, t.Any] | None = None,
         query_class: type[Query] = Query,
-        model_class: _FSA_MCT = Model,  # type: ignore[assignment]
+        model_class: _FSA_MCT_T = Model,  # type: ignore[assignment]
         engine_options: dict[str, t.Any] | None = None,
         add_models_to_shell: bool = True,
         disable_autonaming: bool = False,
@@ -241,29 +353,17 @@ class SQLAlchemy:
             This is a subclass of SQLAlchemy's ``Table`` rather than a function.
         """
 
-        self.Model = self._make_declarative_base(
+        self._Model = self._make_declarative_base(
             model_class, disable_autonaming=disable_autonaming
         )
-        """A SQLAlchemy declarative model class. Subclass this to define database
-        models.
+        """A SQLAlchemy declarative model class. This private model class is returned
+        by ``_make_declarative_base``.
 
-        If a model does not set ``__tablename__``, it will be generated by converting
-        the class name from ``CamelCase`` to ``snake_case``. It will not be generated
-        if the model looks like it uses single-table inheritance.
+        At run time, this class is the same as ``SQLAlchemy.Model``. Accessing
+        ``SQLAlchemy.Model`` rather than this class is more recommended because
+        ``SQLAlchemy.Model`` can provide better type hints.
 
-        If a model or parent class sets ``__bind_key__``, it will use that metadata and
-        database engine. Otherwise, it will use the default :attr:`metadata` and
-        :attr:`engine`. This is ignored if the model sets ``metadata`` or ``__table__``.
-
-        For code using the SQLAlchemy 1.x API, customize this model by subclassing
-        :class:`.Model` and passing the ``model_class`` parameter to the extension.
-        A fully created declarative model class can be
-        passed as well, to use a custom metaclass.
-
-        For code using the SQLAlchemy 2.x API, customize this model by subclassing
-        :class:`sqlalchemy.orm.DeclarativeBase` or
-        :class:`sqlalchemy.orm.DeclarativeBaseNoMeta`
-        and passing the ``model_class`` parameter to the extension.
+        :meta private:
         """
 
         if engine_options is None:
@@ -276,6 +376,31 @@ class SQLAlchemy:
 
         if app is not None:
             self.init_app(app)
+
+    # Need to be placed after __init__ because __init__ takes a default value
+    # named `Model`.
+    Model = ModelGetter()
+    """A SQLAlchemy declarative model class. Subclass this to define database
+    models.
+
+    If a model does not set ``__tablename__``, it will be generated by converting
+    the class name from ``CamelCase`` to ``snake_case``. It will not be generated
+    if the model looks like it uses single-table inheritance.
+
+    If a model or parent class sets ``__bind_key__``, it will use that metadata and
+    database engine. Otherwise, it will use the default :attr:`metadata` and
+    :attr:`engine`. This is ignored if the model sets ``metadata`` or ``__table__``.
+
+    For code using the SQLAlchemy 1.x API, customize this model by subclassing
+    :class:`.Model` and passing the ``model_class`` parameter to the extension.
+    A fully created declarative model class can be
+    passed as well, to use a custom metaclass.
+
+    For code using the SQLAlchemy 2.x API, customize this model by subclassing
+    :class:`sqlalchemy.orm.DeclarativeBase` or
+    :class:`sqlalchemy.orm.DeclarativeBaseNoMeta`
+    and passing the ``model_class`` parameter to the extension.
+    """
 
     def __repr__(self) -> str:
         if not has_app_context():
@@ -503,9 +628,7 @@ class SQLAlchemy:
         return Table
 
     def _make_declarative_base(
-        self,
-        model_class: _FSA_MCT,
-        disable_autonaming: bool = False,
+        self, model_class: _FSA_MCT, disable_autonaming: bool = False
     ) -> t.Type[_FSAModel]:
         """Create a SQLAlchemy declarative model class. The result is available as
         :attr:`Model`.
@@ -534,7 +657,7 @@ class SQLAlchemy:
             ``model`` can be an already created declarative model class.
         """
         model: t.Type[_FSAModel]
-        declarative_bases = _get_2x_declarative_bases(model_class)
+        declarative_bases = _get_2x_declarative_bases(t.cast(t.Any, model_class))
         if len(declarative_bases) > 1:
             # raise error if more than one declarative base is found
             raise ValueError(
@@ -547,11 +670,14 @@ class SQLAlchemy:
             mixin_classes = [BindMixin, NameMixin, Model]
             if disable_autonaming:
                 mixin_classes.remove(NameMixin)
-            model = types.new_class(
-                "FlaskSQLAlchemyBase",
-                (*mixin_classes, *model_class.__bases__),
-                {"metaclass": type(declarative_bases[0])},
-                lambda ns: ns.update(body),
+            model = t.cast(
+                t.Type[_FSAModel],
+                types.new_class(
+                    "FlaskSQLAlchemyBase",
+                    (*mixin_classes, *model_class.__bases__),
+                    {"metaclass": type(declarative_bases[0])},
+                    lambda ns: ns.update(body),
+                ),
             )
         elif not isinstance(model_class, sa_orm.DeclarativeMeta):
             metadata = self._make_metadata(None)

--- a/src/flask_sqlalchemy/model.py
+++ b/src/flask_sqlalchemy/model.py
@@ -33,7 +33,7 @@ class Model:
     already created declarative model class as ``model_class``.
     """
 
-    __fsa__: t.ClassVar[SQLAlchemy]
+    __fsa__: t.ClassVar[SQLAlchemy[t.Any]]
     """Internal reference to the extension object.
 
     :meta private:
@@ -75,7 +75,7 @@ class BindMetaMixin(type):
     directly on the child model.
     """
 
-    __fsa__: SQLAlchemy
+    __fsa__: SQLAlchemy[t.Any]
     metadata: sa.MetaData
 
     def __init__(
@@ -106,7 +106,7 @@ class BindMixin:
     .. versionchanged:: 3.1.0
     """
 
-    __fsa__: SQLAlchemy
+    __fsa__: SQLAlchemy[t.Any]
     metadata: sa.MetaData
 
     @classmethod

--- a/src/flask_sqlalchemy/session.py
+++ b/src/flask_sqlalchemy/session.py
@@ -23,7 +23,7 @@ class Session(sa_orm.Session):
         Renamed from ``SignallingSession``.
     """
 
-    def __init__(self, db: SQLAlchemy, **kwargs: t.Any) -> None:
+    def __init__(self, db: SQLAlchemy[t.Any], **kwargs: t.Any) -> None:
         super().__init__(**kwargs)
         self._db = db
         self._model_changes: dict[object, tuple[t.Any, str]] = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,7 @@ test_classes = [
 
 
 @pytest.fixture(params=test_classes)
-def db(app: Flask, request: pytest.FixtureRequest) -> SQLAlchemy:
+def db(app: Flask, request: pytest.FixtureRequest) -> SQLAlchemy[t.Any]:
     if request.param is not Model:
         return SQLAlchemy(app, model_class=types.new_class(*request.param))
     else:
@@ -79,7 +79,7 @@ def model_class(request: pytest.FixtureRequest) -> t.Any:
 
 
 @pytest.fixture
-def Todo(app: Flask, db: SQLAlchemy) -> t.Generator[t.Any, None, None]:
+def Todo(app: Flask, db: SQLAlchemy[t.Any]) -> t.Generator[t.Any, None, None]:
     if issubclass(db.Model, (sa_orm.MappedAsDataclass)):
 
         class Todo(db.Model):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,7 @@ from flask_sqlalchemy.cli import add_models_to_shell
 
 
 @pytest.mark.usefixtures("app_ctx")
-def test_shell_context(db: SQLAlchemy, Todo: t.Any) -> None:
+def test_shell_context(db: SQLAlchemy[t.Any], Todo: t.Any) -> None:
     context = add_models_to_shell()
     assert context["db"] is db
     assert context["Todo"] is Todo

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -12,7 +12,7 @@ from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 
 
-def test_default_engine(app: Flask, db: SQLAlchemy) -> None:
+def test_default_engine(app: Flask, db: SQLAlchemy[t.Any]) -> None:
     with app.app_context():
         assert db.engine is db.engines[None]
 

--- a/tests/test_extension_object.py
+++ b/tests/test_extension_object.py
@@ -13,7 +13,7 @@ from flask_sqlalchemy.record_queries import get_recorded_queries
 
 
 @pytest.mark.usefixtures("app_ctx")
-def test_get_or_404(db: SQLAlchemy, Todo: t.Any) -> None:
+def test_get_or_404(db: SQLAlchemy[t.Any], Todo: t.Any) -> None:
     item = Todo()
     db.session.add(item)
     db.session.commit()

--- a/tests/test_extension_repr.py
+++ b/tests/test_extension_repr.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import typing as t
+
 from flask import Flask
 
 from flask_sqlalchemy import SQLAlchemy
+from flask_sqlalchemy.model import Model
 
 
 def test_repr_no_context() -> None:
-    db = SQLAlchemy()
+    db: SQLAlchemy[t.Type[Model]] = SQLAlchemy()
     app = Flask(__name__)
     app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
 
@@ -15,7 +18,7 @@ def test_repr_no_context() -> None:
 
 
 def test_repr_default() -> None:
-    db = SQLAlchemy()
+    db: SQLAlchemy[t.Type[Model]] = SQLAlchemy()
     app = Flask(__name__)
     app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
 
@@ -25,7 +28,7 @@ def test_repr_default() -> None:
 
 
 def test_repr_default_plustwo() -> None:
-    db = SQLAlchemy()
+    db: SQLAlchemy[t.Type[Model]] = SQLAlchemy()
     app = Flask(__name__)
     app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
     app.config["SQLALCHEMY_BINDS"] = {
@@ -39,7 +42,7 @@ def test_repr_default_plustwo() -> None:
 
 
 def test_repr_nodefault() -> None:
-    db = SQLAlchemy()
+    db: SQLAlchemy[t.Type[Model]] = SQLAlchemy()
     app = Flask(__name__)
     app.config["SQLALCHEMY_BINDS"] = {"x": "sqlite:///:memory:"}
 
@@ -49,7 +52,7 @@ def test_repr_nodefault() -> None:
 
 
 def test_repr_nodefault_plustwo() -> None:
-    db = SQLAlchemy()
+    db: SQLAlchemy[t.Type[Model]] = SQLAlchemy()
     app = Flask(__name__)
     app.config["SQLALCHEMY_BINDS"] = {
         "a": "sqlite:///:memory:",

--- a/tests/test_legacy_query.py
+++ b/tests/test_legacy_query.py
@@ -10,6 +10,7 @@ from flask import Flask
 from werkzeug.exceptions import NotFound
 
 from flask_sqlalchemy import SQLAlchemy
+from flask_sqlalchemy.model import Model
 from flask_sqlalchemy.query import Query
 
 
@@ -25,7 +26,7 @@ def ignore_query_warning() -> t.Generator[None, None, None]:
 
 
 @pytest.mark.usefixtures("app_ctx")
-def test_get_or_404(db: SQLAlchemy, Todo: t.Any) -> None:
+def test_get_or_404(db: SQLAlchemy[t.Any], Todo: t.Any) -> None:
     item = Todo()
     db.session.add(item)
     db.session.commit()
@@ -36,7 +37,7 @@ def test_get_or_404(db: SQLAlchemy, Todo: t.Any) -> None:
 
 
 @pytest.mark.usefixtures("app_ctx")
-def test_first_or_404(db: SQLAlchemy, Todo: t.Any) -> None:
+def test_first_or_404(db: SQLAlchemy[t.Any], Todo: t.Any) -> None:
     db.session.add(Todo(title="a"))
     db.session.commit()
     assert Todo.query.filter_by(title="a").first_or_404().title == "a"
@@ -46,7 +47,7 @@ def test_first_or_404(db: SQLAlchemy, Todo: t.Any) -> None:
 
 
 @pytest.mark.usefixtures("app_ctx")
-def test_one_or_404(db: SQLAlchemy, Todo: t.Any) -> None:
+def test_one_or_404(db: SQLAlchemy[t.Any], Todo: t.Any) -> None:
     db.session.add(Todo(title="a"))
     db.session.add(Todo(title="b"))
     db.session.add(Todo(title="b"))
@@ -63,7 +64,7 @@ def test_one_or_404(db: SQLAlchemy, Todo: t.Any) -> None:
 
 
 @pytest.mark.usefixtures("app_ctx")
-def test_paginate(db: SQLAlchemy, Todo: t.Any) -> None:
+def test_paginate(db: SQLAlchemy[t.Any], Todo: t.Any) -> None:
     db.session.add_all(Todo() for _ in range(150))
     db.session.commit()
     p = Todo.query.paginate()
@@ -75,7 +76,7 @@ def test_paginate(db: SQLAlchemy, Todo: t.Any) -> None:
 
 
 @pytest.mark.usefixtures("app_ctx")
-def test_default_query_class(db: SQLAlchemy) -> None:
+def test_default_query_class(db: SQLAlchemy[t.Any]) -> None:
     class Parent(db.Model):
         id = sa.Column(sa.Integer, primary_key=True)
         children1 = db.relationship("Child", backref="parent1", lazy="dynamic")
@@ -101,7 +102,7 @@ def test_custom_query_class(app: Flask) -> None:
     class CustomQuery(Query):
         pass
 
-    db = SQLAlchemy(app, query_class=CustomQuery)
+    db: SQLAlchemy[t.Type[Model]] = SQLAlchemy(app, query_class=CustomQuery)
 
     class Parent(db.Model):
         id = sa.Column(sa.Integer, primary_key=True)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -13,7 +13,7 @@ from flask_sqlalchemy.model import DefaultMeta
 from flask_sqlalchemy.model import Model
 
 
-def test_default_metadata(db: SQLAlchemy) -> None:
+def test_default_metadata(db: SQLAlchemy[t.Any]) -> None:
     assert db.metadata is db.metadatas[None]
     assert db.metadata.info["bind_key"] is None
     assert db.Model.metadata is db.metadata
@@ -21,7 +21,7 @@ def test_default_metadata(db: SQLAlchemy) -> None:
 
 def test_custom_metadata_1x() -> None:
     metadata = sa.MetaData()
-    db = SQLAlchemy(metadata=metadata)
+    db: SQLAlchemy[t.Any] = SQLAlchemy(metadata=metadata)
     assert db.metadata is metadata
     assert db.metadata.info["bind_key"] is None
     assert db.Model.metadata is db.metadata
@@ -34,7 +34,9 @@ def test_custom_metadata_2x_wrongway() -> None:
         pass
 
     with pytest.deprecated_call():
-        db = SQLAlchemy(model_class=Base, metadata=custom_metadata)
+        db: SQLAlchemy[t.Type[Base]] = SQLAlchemy(
+            model_class=Base, metadata=custom_metadata
+        )
 
         assert db.metadata is Base.metadata
         assert db.metadata.info["bind_key"] is None
@@ -88,7 +90,7 @@ def test_copy_naming_convention(app: Flask, model_class: t.Any) -> None:
         model_class.metadata = sa.MetaData(
             naming_convention={"pk": "spk_%(table_name)s"}
         )
-        db = SQLAlchemy(app, model_class=model_class)
+        db: SQLAlchemy[t.Type[t.Any]] = SQLAlchemy(app, model_class=model_class)
     else:
         db = SQLAlchemy(
             app, metadata=sa.MetaData(naming_convention={"pk": "spk_%(table_name)s"})
@@ -100,7 +102,7 @@ def test_copy_naming_convention(app: Flask, model_class: t.Any) -> None:
 @pytest.mark.usefixtures("app_ctx")
 def test_create_drop_all(app: Flask) -> None:
     app.config["SQLALCHEMY_BINDS"] = {"a": "sqlite://"}
-    db = SQLAlchemy(app)
+    db: SQLAlchemy[t.Type[Model]] = SQLAlchemy(app)
 
     class User(db.Model):
         id = sa.Column(sa.Integer, primary_key=True)
@@ -131,7 +133,7 @@ def test_create_drop_all(app: Flask) -> None:
 @pytest.mark.parametrize("bind_key", ["a", ["a"]])
 def test_create_key_spec(app: Flask, bind_key: str | list[str | None]) -> None:
     app.config["SQLALCHEMY_BINDS"] = {"a": "sqlite://"}
-    db = SQLAlchemy(app)
+    db: SQLAlchemy[t.Type[Model]] = SQLAlchemy(app)
 
     class User(db.Model):
         id = sa.Column(sa.Integer, primary_key=True)
@@ -151,7 +153,7 @@ def test_create_key_spec(app: Flask, bind_key: str | list[str | None]) -> None:
 def test_reflect(app: Flask) -> None:
     app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///user.db"
     app.config["SQLALCHEMY_BINDS"] = {"post": "sqlite:///post.db"}
-    db = SQLAlchemy(app)
+    db: SQLAlchemy[t.Type[Model]] = SQLAlchemy(app)
     db.Table("user", sa.Column("id", sa.Integer, primary_key=True))
     db.Table("post", sa.Column("id", sa.Integer, primary_key=True), bind_key="post")
     db.create_all()

--- a/tests/test_model_bind.py
+++ b/tests/test_model_bind.py
@@ -1,18 +1,20 @@
 from __future__ import annotations
 
+import typing as t
+
 import sqlalchemy as sa
 
 from flask_sqlalchemy import SQLAlchemy
 
 
-def test_bind_key_default(db: SQLAlchemy) -> None:
+def test_bind_key_default(db: SQLAlchemy[t.Any]) -> None:
     class User(db.Model):
         id = sa.Column(sa.Integer, primary_key=True)
 
     assert User.metadata is db.metadata
 
 
-def test_metadata_per_bind(db: SQLAlchemy) -> None:
+def test_metadata_per_bind(db: SQLAlchemy[t.Any]) -> None:
     class User(db.Model):
         __bind_key__ = "other"
         id = sa.Column(sa.Integer, primary_key=True)
@@ -20,7 +22,7 @@ def test_metadata_per_bind(db: SQLAlchemy) -> None:
     assert User.metadata is db.metadatas["other"]
 
 
-def test_multiple_binds_same_table_name(db: SQLAlchemy) -> None:
+def test_multiple_binds_same_table_name(db: SQLAlchemy[t.Any]) -> None:
     class UserA(db.Model):
         __tablename__ = "user"
         id = sa.Column(sa.Integer, primary_key=True)
@@ -35,7 +37,7 @@ def test_multiple_binds_same_table_name(db: SQLAlchemy) -> None:
     assert UserA.__table__.metadata is not UserB.__table__.metadata
 
 
-def test_inherit_parent(db: SQLAlchemy) -> None:
+def test_inherit_parent(db: SQLAlchemy[t.Any]) -> None:
     class User(db.Model):
         __bind_key__ = "auth"
         id = sa.Column(sa.Integer, primary_key=True)
@@ -51,7 +53,7 @@ def test_inherit_parent(db: SQLAlchemy) -> None:
     assert "metadata" not in Admin.__dict__
 
 
-def test_inherit_abstract_parent(db: SQLAlchemy) -> None:
+def test_inherit_abstract_parent(db: SQLAlchemy[t.Any]) -> None:
     class AbstractUser(db.Model):
         __abstract__ = True
         __bind_key__ = "auth"
@@ -63,7 +65,7 @@ def test_inherit_abstract_parent(db: SQLAlchemy) -> None:
     assert "metadata" not in User.__dict__
 
 
-def test_explicit_metadata(db: SQLAlchemy) -> None:
+def test_explicit_metadata(db: SQLAlchemy[t.Any]) -> None:
     other_metadata = sa.MetaData()
 
     class User(db.Model):
@@ -75,7 +77,7 @@ def test_explicit_metadata(db: SQLAlchemy) -> None:
     assert "other" not in db.metadatas
 
 
-def test_explicit_table(db: SQLAlchemy) -> None:
+def test_explicit_table(db: SQLAlchemy[t.Any]) -> None:
     user_table = db.Table(
         "user",
         sa.Column("id", sa.Integer, primary_key=True),

--- a/tests/test_model_name.py
+++ b/tests/test_model_name.py
@@ -48,7 +48,7 @@ def test_camel_to_snake_case(name: str, expect: str) -> None:
     assert camel_to_snake_case(name) == expect
 
 
-def test_name(db: SQLAlchemy) -> None:
+def test_name(db: SQLAlchemy[t.Any]) -> None:
     class FOOBar(db.Model):
         id = sa.Column(sa.Integer, primary_key=True)
 
@@ -64,7 +64,7 @@ def test_name(db: SQLAlchemy) -> None:
     assert Ham.__tablename__ == "spam"
 
 
-def test_single_name(db: SQLAlchemy) -> None:
+def test_single_name(db: SQLAlchemy[t.Any]) -> None:
     """Single table inheritance should not set a new name."""
 
     class Duck(db.Model):
@@ -77,7 +77,7 @@ def test_single_name(db: SQLAlchemy) -> None:
     assert Mallard.__tablename__ == "duck"
 
 
-def test_joined_name(db: SQLAlchemy) -> None:
+def test_joined_name(db: SQLAlchemy[t.Any]) -> None:
     """Model has a separate primary key; it should set a new name."""
 
     class Duck(db.Model):
@@ -89,7 +89,7 @@ def test_joined_name(db: SQLAlchemy) -> None:
     assert Donald.__tablename__ == "donald"
 
 
-def test_mixin_id(db: SQLAlchemy) -> None:
+def test_mixin_id(db: SQLAlchemy[t.Any]) -> None:
     """Primary key provided by mixin should still allow model to set
     tablename.
     """
@@ -104,7 +104,7 @@ def test_mixin_id(db: SQLAlchemy) -> None:
     assert Duck.__tablename__ == "duck"
 
 
-def test_mixin_attr(db: SQLAlchemy) -> None:
+def test_mixin_attr(db: SQLAlchemy[t.Any]) -> None:
     """A declared attr tablename will be used down multiple levels of
     inheritance.
     """
@@ -130,7 +130,7 @@ def test_mixin_attr(db: SQLAlchemy) -> None:
     assert Mallard.__tablename__ == "MALLARD"
 
 
-def test_abstract_name(db: SQLAlchemy) -> None:
+def test_abstract_name(db: SQLAlchemy[t.Any]) -> None:
     """Abstract model should not set a name. Subclass should set a name."""
 
     class Base(db.Model):
@@ -144,7 +144,7 @@ def test_abstract_name(db: SQLAlchemy) -> None:
     assert Duck.__tablename__ == "duck"
 
 
-def test_complex_inheritance(db: SQLAlchemy) -> None:
+def test_complex_inheritance(db: SQLAlchemy[t.Any]) -> None:
     """Joined table inheritance, but the new primary key is provided by a
     mixin, not directly on the class.
     """
@@ -163,7 +163,7 @@ def test_complex_inheritance(db: SQLAlchemy) -> None:
     assert RubberDuck.__tablename__ == "rubber_duck"
 
 
-def test_manual_name(db: SQLAlchemy) -> None:
+def test_manual_name(db: SQLAlchemy[t.Any]) -> None:
     """Setting a manual name prevents generation for the immediate model. A
     name is generated for joined but not single-table inheritance.
     """
@@ -189,7 +189,7 @@ def test_manual_name(db: SQLAlchemy) -> None:
     assert Donald.__tablename__ == "DUCK"
 
 
-def test_primary_constraint(db: SQLAlchemy) -> None:
+def test_primary_constraint(db: SQLAlchemy[t.Any]) -> None:
     """Primary key will be picked up from table args."""
 
     class Duck(db.Model):
@@ -201,7 +201,7 @@ def test_primary_constraint(db: SQLAlchemy) -> None:
     assert Duck.__tablename__ == "duck"
 
 
-def test_no_access_to_class_property(db: SQLAlchemy) -> None:
+def test_no_access_to_class_property(db: SQLAlchemy[t.Any]) -> None:
     """Ensure the implementation doesn't access class properties or declared
     attrs while inspecting the unmapped model.
     """
@@ -237,7 +237,7 @@ def test_no_access_to_class_property(db: SQLAlchemy) -> None:
     assert not ns.floats
 
 
-def test_metadata_has_table(db: SQLAlchemy) -> None:
+def test_metadata_has_table(db: SQLAlchemy[t.Any]) -> None:
     user = db.Table("user", sa.Column("id", sa.Integer, primary_key=True))
 
     class User(db.Model):
@@ -246,7 +246,7 @@ def test_metadata_has_table(db: SQLAlchemy) -> None:
     assert User.__table__ is user
 
 
-def test_correct_error_for_no_primary_key(db: SQLAlchemy) -> None:
+def test_correct_error_for_no_primary_key(db: SQLAlchemy[t.Any]) -> None:
     with pytest.raises(sa_exc.ArgumentError) as info:
 
         class User(db.Model):
@@ -255,7 +255,7 @@ def test_correct_error_for_no_primary_key(db: SQLAlchemy) -> None:
     assert "could not assemble any primary key" in str(info.value)
 
 
-def test_single_has_parent_table(db: SQLAlchemy) -> None:
+def test_single_has_parent_table(db: SQLAlchemy[t.Any]) -> None:
     class Duck(db.Model):
         id = sa.Column(sa.Integer, primary_key=True)
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -119,7 +119,7 @@ def test_iter_pages_short(page: int) -> None:
 
 
 class _PaginateCallable:
-    def __init__(self, app: Flask, db: SQLAlchemy, Todo: t.Any) -> None:
+    def __init__(self, app: Flask, db: SQLAlchemy[t.Any], Todo: t.Any) -> None:
         self.app = app
         self.db = db
         self.Todo = Todo
@@ -143,7 +143,7 @@ class _PaginateCallable:
 
 
 @pytest.fixture
-def paginate(app: Flask, db: SQLAlchemy, Todo: t.Any) -> _PaginateCallable:
+def paginate(app: Flask, db: SQLAlchemy[t.Any], Todo: t.Any) -> _PaginateCallable:
     with app.app_context():
         for i in range(1, 251):
             db.session.add(Todo(title=f"task {i}"))
@@ -197,7 +197,7 @@ def test_error_out(paginate: _PaginateCallable, page: t.Any, per_page: t.Any) ->
 
 
 @pytest.mark.usefixtures("app_ctx")
-def test_no_items_404(db: SQLAlchemy, Todo: t.Any) -> None:
+def test_no_items_404(db: SQLAlchemy[t.Any], Todo: t.Any) -> None:
     p = db.paginate(db.select(Todo))
     assert len(p.items) == 0
 

--- a/tests/test_record_queries.py
+++ b/tests/test_record_queries.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import typing as t
 
 import pytest
 import sqlalchemy as sa
@@ -8,13 +9,14 @@ import sqlalchemy.orm as sa_orm
 from flask import Flask
 
 from flask_sqlalchemy import SQLAlchemy
+from flask_sqlalchemy.model import Model
 from flask_sqlalchemy.record_queries import get_recorded_queries
 
 
 @pytest.mark.usefixtures("app_ctx")
 def test_query_info(app: Flask) -> None:
     app.config["SQLALCHEMY_RECORD_QUERIES"] = True
-    db = SQLAlchemy(app)
+    db: SQLAlchemy[t.Type[Model]] = SQLAlchemy(app)
 
     # Copied and pasted from conftest.py
     if issubclass(db.Model, (sa_orm.MappedAsDataclass)):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -11,7 +11,7 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_sqlalchemy.session import Session
 
 
-def test_scope(app: Flask, db: SQLAlchemy) -> None:
+def test_scope(app: Flask, db: SQLAlchemy[t.Any]) -> None:
     with pytest.raises(RuntimeError):
         db.session()
 

--- a/tests/test_table_bind.py
+++ b/tests/test_table_bind.py
@@ -1,23 +1,25 @@
 from __future__ import annotations
 
+import typing as t
+
 import sqlalchemy as sa
 
 from flask_sqlalchemy import SQLAlchemy
 
 
-def test_bind_key_default(db: SQLAlchemy) -> None:
+def test_bind_key_default(db: SQLAlchemy[t.Any]) -> None:
     user_table = db.Table("user", sa.Column("id", sa.Integer, primary_key=True))
     assert user_table.metadata is db.metadata
 
 
-def test_metadata_per_bind(db: SQLAlchemy) -> None:
+def test_metadata_per_bind(db: SQLAlchemy[t.Any]) -> None:
     user_table = db.Table(
         "user", sa.Column("id", sa.Integer, primary_key=True), bind_key="other"
     )
     assert user_table.metadata is db.metadatas["other"]
 
 
-def test_multiple_binds_same_table_name(db: SQLAlchemy) -> None:
+def test_multiple_binds_same_table_name(db: SQLAlchemy[t.Any]) -> None:
     user1_table = db.Table("user", sa.Column("id", sa.Integer, primary_key=True))
     user2_table = db.Table(
         "user", sa.Column("id", sa.Integer, primary_key=True), bind_key="other"
@@ -27,7 +29,7 @@ def test_multiple_binds_same_table_name(db: SQLAlchemy) -> None:
     assert user2_table.metadata is db.metadatas["other"]
 
 
-def test_explicit_metadata(db: SQLAlchemy) -> None:
+def test_explicit_metadata(db: SQLAlchemy[t.Any]) -> None:
     other_metadata = sa.MetaData()
     user_table = db.Table(
         "user",

--- a/tests/test_view_query.py
+++ b/tests/test_view_query.py
@@ -12,7 +12,7 @@ from flask_sqlalchemy import SQLAlchemy
 
 
 @pytest.mark.usefixtures("app_ctx")
-def test_view_get_or_404(db: SQLAlchemy, Todo: t.Any) -> None:
+def test_view_get_or_404(db: SQLAlchemy[t.Any], Todo: t.Any) -> None:
     item = Todo()
     db.session.add(item)
     db.session.commit()
@@ -22,7 +22,7 @@ def test_view_get_or_404(db: SQLAlchemy, Todo: t.Any) -> None:
 
 
 @pytest.mark.usefixtures("app_ctx")
-def test_first_or_404(db: SQLAlchemy, Todo: t.Any) -> None:
+def test_first_or_404(db: SQLAlchemy[t.Any], Todo: t.Any) -> None:
     db.session.add(Todo(title="a"))
     db.session.commit()
     result = db.first_or_404(db.select(Todo).filter_by(title="a"))
@@ -33,7 +33,7 @@ def test_first_or_404(db: SQLAlchemy, Todo: t.Any) -> None:
 
 
 @pytest.mark.usefixtures("app_ctx")
-def test_view_one_or_404(db: SQLAlchemy, Todo: t.Any) -> None:
+def test_view_one_or_404(db: SQLAlchemy[t.Any], Todo: t.Any) -> None:
     db.session.add(Todo(title="a"))
     db.session.add(Todo(title="b"))
     db.session.add(Todo(title="b"))
@@ -51,7 +51,7 @@ def test_view_one_or_404(db: SQLAlchemy, Todo: t.Any) -> None:
 
 
 @pytest.mark.usefixtures("app_ctx")
-def test_paginate(db: SQLAlchemy, Todo: t.Any) -> None:
+def test_paginate(db: SQLAlchemy[t.Any], Todo: t.Any) -> None:
     db.session.add_all(Todo() for _ in range(150))
     db.session.commit()
     p = db.paginate(db.select(Todo))
@@ -64,7 +64,7 @@ def test_paginate(db: SQLAlchemy, Todo: t.Any) -> None:
 
 # This test creates its own inline model so that it can use that as the type
 @pytest.mark.usefixtures("app_ctx")
-def test_view_get_or_404_typed(db: SQLAlchemy, app: Flask) -> None:
+def test_view_get_or_404_typed(db: SQLAlchemy[t.Any], app: Flask) -> None:
     # Copied and pasted from conftest.py
     if issubclass(db.Model, (sa_orm.MappedAsDataclass)):
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,12 +23,14 @@ commands = pytest -v --tb=short --basetemp={envtmpdir} {posargs}
 deps = pre-commit
 skip_install = true
 commands = pre-commit run --all-files
+allowlist_externals = mypy
 
 [testenv:typing]
 deps = -r requirements/mypy.txt
 commands =
     mypy --python-version 3.8
     mypy --python-version 3.11
+allowlist_externals = mypy
 
 [testenv:docs]
 deps = -r requirements/docs.txt


### PR DESCRIPTION
Fix the typehint inconsistence of `db.relationship(...)`.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #1312
- Fix an issue when tox p fails because mypy is forbidden (necessary for passing tests)
   - This issue may be caused by upgrade of `tox>=4`. My `tox` version is `4.12.0`.
   - See details here: https://stackoverflow.com/a/47716994/8266012

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
  - Only bug fixing. No need to do this.
- [ ] Add or update relevant docs, in the docs folder and in code.
  - Only bug fixing. No need to do this.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
  - Only bug fixing. No need to add any change logs for users.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
  - Only bug fixing. No need to do this.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.

## Appendix

This PR only changes the behavior during the static type checking. In other words, at run time, the codes work totally the same as the original version. I made this customization because I think the original codes only have type checking issues but work perfectly at run time. That's why I do not submit any changelogs here, because actually I did not change any functionalities or behaviors at run time.

The following code can be used for testing the performance of the type hints provided by this PR. It works perfected in most cases. However, there are two known cases that the type check shows false negative results. See `test_not_as_expectation`.

It seems that the static type checking codes cannot be added to pytest. That's why I do not add more tests for this PR.

```python
from typing import Type, Any
from typing_extensions import reveal_type

import dataclasses
import sqlalchemy.orm as sa_orm

from flask_sqlalchemy import SQLAlchemy
from flask_sqlalchemy.model import DefaultMeta, Model


def test_default() -> None:
    db = SQLAlchemy()
    reveal_type(db)  # SQLAlchemy[type[Model]]
    reveal_type(db.Model)  # type[_FSAModel_KW]


def test_unknown_class(model_class: Any) -> None:
    db = SQLAlchemy(model_class=model_class)
    reveal_type(db)  # SQLAlchemy[Any]
    reveal_type(db.Model)  # type[_FSAModel_KW]


def test_meta_class_v1(meta_class: Type[sa_orm.DeclarativeMeta]) -> None:
    db = SQLAlchemy(model_class=meta_class(type))
    reveal_type(db)  # SQLAlchemy[type[__class_type]]
    reveal_type(db.Model)  # type[_FSAModel_KW]

    class TestClass(metaclass=meta_class):
        pass

    db_v2 = SQLAlchemy(model_class=TestClass)
    reveal_type(db_v2)  # SQLAlchemy[type[TestClass]]
    reveal_type(db_v2.Model)  # type[_FSAModel_KW]


def test_meta_class_v2(meta_class: Type[DefaultMeta]) -> None:
    db = SQLAlchemy(model_class=meta_class(type))
    reveal_type(db)  # SQLAlchemy[type[__class_type]]
    reveal_type(db.Model)  # type[_FSAModel_KW]

    class TestClass(metaclass=meta_class):
        pass

    db_v2 = SQLAlchemy(model_class=TestClass)
    reveal_type(db_v2)  # SQLAlchemy[type[TestClass]]
    reveal_type(db_v2.Model)  # type[_FSAModel_KW]


def test_sqlalchemy2_base(model_class: Type[sa_orm.DeclarativeBase]) -> None:
    db = SQLAlchemy(model_class=model_class)
    reveal_type(db)  # SQLAlchemy[type[DeclarativeBase]]
    reveal_type(db.Model)  # type[_FSAModel_KW]


def test_sqlalchemy2_nometa(model_class: Type[sa_orm.DeclarativeBaseNoMeta]) -> None:
    db = SQLAlchemy(model_class=model_class)
    reveal_type(db)  # SQLAlchemy[type[DeclarativeBaseNoMeta]]
    reveal_type(db.Model)  # type[_FSAModel_KW]


def test_sqlalchemy2_dataclass(model_class: Type[sa_orm.MappedAsDataclass]) -> None:
    db = SQLAlchemy(model_class=model_class)
    reveal_type(db)  # SQLAlchemy[type[MappedAsDataclass]]
    reveal_type(db.Model)  # type[_FSAModel_DataClass]


def test_sqlalchemy2_hybird() -> None:

    class Base1(sa_orm.MappedAsDataclass, sa_orm.DeclarativeBase):
        pass

    db1 = SQLAlchemy(model_class=Base1)
    reveal_type(db1)  # SQLAlchemy[type[Base1]]
    reveal_type(db1.Model)  # type[_FSAModel_DataClass]

    class Base2(sa_orm.DeclarativeBase, sa_orm.MappedAsDataclass):
        pass

    db2 = SQLAlchemy(model_class=Base2)
    reveal_type(db2)  # SQLAlchemy[type[Base2]]
    reveal_type(db2.Model)  # type[_FSAModel_DataClass]

    class AnyClass:
        pass

    class Base3(sa_orm.DeclarativeBase, AnyClass):
        pass

    db3 = SQLAlchemy(model_class=Base3)
    reveal_type(db3)  # SQLAlchemy[type[Base3]]
    reveal_type(db3.Model)  # type[_FSAModel_KW]


def test_class_init_kw():
    class BaseKW(sa_orm.DeclarativeBase):
        pass

    db = SQLAlchemy(model_class=BaseKW)
    reveal_type(db)  # SQLAlchemy[type[BaseKW]]
    reveal_type(db.Model)  # type[_FSAModel_KW]

    class ModelSa(BaseKW):
        __tablename__ = "modelsas"
        id: sa_orm.Mapped[int] = sa_orm.mapped_column(primary_key=True)
        name: sa_orm.Mapped[str]

    class ModelDb(db.Model):
        id: sa_orm.Mapped[int] = sa_orm.mapped_column(primary_key=True)
        name: sa_orm.Mapped[str]

    # Well done! Now db.Model works in the same way compared to the base class.
    reveal_type(ModelSa.__init__)  # (self: ModelSa, **kw: Any) -> None
    reveal_type(ModelDb.__init__)  # (self: ModelDb, **kw: Any) -> None


def test_class_init_kw_v2():
    BaseKWMeta = sa_orm.declarative_base()
    assert isinstance(BaseKWMeta, sa_orm.DeclarativeMeta)
    assert not issubclass(BaseKWMeta, sa_orm.DeclarativeBase)
    assert not issubclass(BaseKWMeta, sa_orm.DeclarativeBaseNoMeta)
    assert not issubclass(BaseKWMeta, sa_orm.MappedAsDataclass)

    db = SQLAlchemy(model_class=BaseKWMeta)
    reveal_type(db)  # SQLAlchemy[type[BaseKWMeta]]
    reveal_type(db.Model)  # type[_FSAModel_KW]

    class ModelSa(BaseKWMeta):
        __tablename__ = "modelsas"
        id: sa_orm.Mapped[int] = sa_orm.mapped_column(primary_key=True)
        name: sa_orm.Mapped[str]

    class ModelDb(db.Model):
        __tablename__ = "modeldbs"
        id: sa_orm.Mapped[int] = sa_orm.mapped_column(primary_key=True)
        name: sa_orm.Mapped[str]

    # Note that the typehint of `ModelSa.__init__` is wrong. It is not consistent with
    # the run-time usage. However, `ModelDb.__init__` is consistent. In otherwords,
    # both ModelSa(name="name") and ModelDb(name="name") can work at run time.
    reveal_type(ModelSa.__init__)  # (self: ModelSa) -> None
    reveal_type(ModelDb.__init__)  # (self: ModelDb, **kw: Any) -> None


def test_class_init_dataclass():
    class BaseDataClass(sa_orm.DeclarativeBase, sa_orm.MappedAsDataclass):
        pass

    db = SQLAlchemy(model_class=BaseDataClass)
    reveal_type(db)  # SQLAlchemy[type[BaseDataClass]]
    reveal_type(db.Model)  # type[_FSAModel_DataClass]

    class ModelSa(BaseDataClass):
        __tablename__ = "modelsas"
        id: sa_orm.Mapped[int] = sa_orm.mapped_column(primary_key=True)
        name: sa_orm.Mapped[str]

    class ModelDb(db.Model):
        id: sa_orm.Mapped[int] = sa_orm.mapped_column(primary_key=True)
        name: sa_orm.Mapped[str]

    # Well done! Now db.Model works in the same way compared to the base class.
    reveal_type(ModelSa.__init__)  # (self: ModelSa, name: SQLCoreOperations[str] | str) -> None
    reveal_type(ModelDb.__init__)  # (self: ModelDb, name: SQLCoreOperations[str] | str) -> None


def test_not_allowed():

    class Pass1(metaclass=sa_orm.DeclarativeMeta):
        pass

    reveal_type(SQLAlchemy(model_class=Pass1))  # SQLAlchemy[type[Pass1]]

    class Pass2(metaclass=DefaultMeta):
        pass

    reveal_type(SQLAlchemy(model_class=Pass2))  # SQLAlchemy[type[Pass2]]

    class Pass3(Model):
        pass

    reveal_type(SQLAlchemy(model_class=Pass3))  # SQLAlchemy[type[Pass3]]

    class Pass4(sa_orm.DeclarativeBase):
        pass

    reveal_type(SQLAlchemy(model_class=Pass4))  # SQLAlchemy[type[Pass4]]

    class Pass5(sa_orm.DeclarativeBaseNoMeta):
        pass

    reveal_type(SQLAlchemy(model_class=Pass5))  # SQLAlchemy[type[Pass5]]

    class Pass6(sa_orm.DeclarativeBase, sa_orm.MappedAsDataclass):
        pass

    reveal_type(SQLAlchemy(model_class=Pass6))  # SQLAlchemy[type[Pass6]]

    class NotPass1:
        pass

    # As expectation
    # Argument of type "type[NotPass1]" cannot be assigned to parameter "model_class"
    # of type "_FSA_MCT_T@SQLAlchemy" in function "__init__"
    SQLAlchemy(model_class=NotPass1)

    class NotPass2(sa_orm.DeclarativeMeta):
        pass

    # As expectation
    # Argument of type "type[NotPass2]" cannot be assigned to parameter "model_class"
    # of type "_FSA_MCT_T@SQLAlchemy" in function "__init__"
    SQLAlchemy(model_class=NotPass2)

    @dataclasses.dataclass
    class NotPass3:
        a: int = dataclasses.field(default=1)

    # As expectation
    # Argument of type "type[NotPass3]" cannot be assigned to parameter "model_class"
    # of type "_FSA_MCT_T@SQLAlchemy" in function "__init__"
    SQLAlchemy(model_class=NotPass3)


def test_not_as_expectation():
    """The following cases show the limitation of the current implementation. In the
    following tests, such usages should not be allowed and will raise run time errors.
    However, the current implementation cannot reveal the errors during the static
    type checks.

    I do not have a good idea to solve them. I think maybe these cases can be left as
    they are.
    """

    class Base(sa_orm.DeclarativeBase, sa_orm.MappedAsDataclass):
        pass

    class Unexpected1(Base):
        __tablename__ = "unexpecteds1"
        id: sa_orm.Mapped[int] = sa_orm.mapped_column(primary_key=True, init=False)
        a: sa_orm.Mapped[int]

    # `Unexpected1` should not be used as the model_class. But the type checker allows
    # this usage.
    reveal_type(SQLAlchemy(model_class=Unexpected1))  # SQLAlchemy[type[Unexpected1]]

    class Unexpected2(sa_orm.MappedAsDataclass):
        pass

    # `Unexpected2` does not inherit `DeclarativeBase`. It should not be used as the
    # `model_class`. However, currently, we allow it. That's because Python does not
    # support typing like `Intersection[ParentClass1, ParentClass2]` yet. If we want
    # `SQLAlchemy` to be aware of `MappedAsDataclass`, this class has to be accepted
    # as the input candidate of `model_class`.
    reveal_type(SQLAlchemy(model_class=Unexpected2))  # SQLAlchemy[type[Unexpected2]]
```