### PR TITLE
Ignore unclosed sqlite connection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@ Version 3.1.2
 -------------
 
 - Fix issue with calling ``repr()`` on ``SQLAlchemy`` instance with no default engine. :issue:`1295`
+- Ignore unclosed sqlite connection in tests. :issue:`1379`
 
 
 Version 3.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ exclude = [
 testpaths = ["tests"]
 filterwarnings = [
     "error",
+    "ignore:unclosed database in <sqlite3.Connection:ResourceWarning",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
This matches
https://github.com/ipython/ipykernel/pull/1277/commits/947894b8c0f52cc1ecbfb1600f27112ee1632445, and there doesn't seem to be a sensible alternative at the moment.

Fixes: #1379