### PR TITLE
tests: MappedAsDataclass - skip table binding

### DIFF
--- a/tests/test_model_bind.py
+++ b/tests/test_model_bind.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import pytest
 import sqlalchemy as sa
+import sqlalchemy.orm as sa_orm
 
 from flask_sqlalchemy import SQLAlchemy
 
@@ -76,6 +78,9 @@ def test_explicit_metadata(db: SQLAlchemy) -> None:
 
 
 def test_explicit_table(db: SQLAlchemy) -> None:
+    if issubclass(db.Model, (sa_orm.MappedAsDataclass)):
+        pytest.skip("Explicit table binding with mapped dataclasses not supported")
+
     user_table = db.Table(
         "user",
         sa.Column("id", sa.Integer, primary_key=True),


### PR DESCRIPTION
With SQLAlchemy 2.0.36 mapping as a dataclass while also providing a ``__table__`` attribute is not supported.

Skip associated test when ``MappedAsDataclass`` is in use.

Fixes: #1378

See https://github.com/sqlalchemy/sqlalchemy/commit/6ae7f2378971b16f024eb5ab851cc4533bc4e61a for associated behaviour change in SQLAlchemy