### PR TITLE
Remove unused import in Quick Start Define Models

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -111,7 +111,6 @@ The model will generate a table name by converting the ``CamelCase`` class name 
 
 .. code-block:: python
 
-    from sqlalchemy import Integer, String
     from sqlalchemy.orm import Mapped, mapped_column
 
     class User(db.Model):


### PR DESCRIPTION
Hello flask-sqlalchemy folks,

Thank you for updating the documentation to show off the 2.0 way of using SQLAlchemy. I've been re-reading through the Flask-SQLAlchemy documentation as part of upgrading a project that had originally been on SQLAlchemy 1.x, and learning about (and using) new things like `sqlalchemy.orm.Mapped` and `sqlalchemy.orm.mapped_column` has been very helpful.

This one-line PR removes an unused import statement from the documentation that I think may have been left over from the pre-mapped_column days. The PR template says to add a line to CHANGES.rst, but it looks like the existing pattern is to not update that file for minor documentation changes, so I did not touch that file.