### PR TITLE
Use SQLALCHEMY_ENGINE_OPTIONS as default engine options

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,7 +39,7 @@ jobs:
           cache: pip
           cache-dependency-path: requirements*/*.txt
       - name: cache mypy
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+        uses: actions/cache@v4 # v4.1.2
         with:
           path: ./.mypy_cache
           key: mypy|${{ hashFiles('pyproject.toml') }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Version 3.1.3
+-------------
+
+- Use ``SQLALCHEMY_ENGINE_OPTIONS`` as default engine options specifically when engine options is not specified in ``SQLALCHEMY_BINDS``. :issue:`1396`
+
+
 Version 3.1.2
 -------------
 

--- a/src/flask_sqlalchemy/extension.py
+++ b/src/flask_sqlalchemy/extension.py
@@ -342,6 +342,7 @@ class SQLAlchemy:
             engine_options[key] = self._engine_options.copy()
 
             if isinstance(value, (str, sa.engine.URL)):
+                engine_options[key].update(basic_engine_options)
                 engine_options[key]["url"] = value
             else:
                 engine_options[key].update(value)


### PR DESCRIPTION
use SQLALCHEMY_ENGINE_OPTIONS as default engine options if engine options is not specified in SQLALCHEMY_BINDS

When engine options is not specified in <code>SQLALCHEMY_BINDS</code>, this engine will lack options with the bind. Which may cause some unexpected errors such as database disconnect error. 
<pre>
SQLALCHEMY_BINDS = {"main": "mysql+pymysql://root:root@localhost:3306/dbname"}
SQLALCHEMY_ENGINE_OPTIONS = {"pool_pre_ping": True}
</pre>
For example, if someone use Flask-SQLalchemy like this, he will think <code>SQLALCHEMY_ENGINE_OPTIONS</code> will make effect in <code>SQLALCHEMY_BINDS</code>. But that's not the case. 

This PR use <code>SQLALCHEMY_ENGINE_OPTIONS</code> as default engine options specifically when engine options is not specified in <code>SQLALCHEMY_BINDS</code>. So the code above will be same as 
<pre>
SQLALCHEMY_BINDS = {
    "main": {
        "url": "mysql+pymysql://root:root@localhost:3306/dbname",
        "pool_pre_ping": True
    }
}
</pre>


fixes [#1396](https://github.com/pallets-eco/flask-sqlalchemy/issues/1396)