### PR TITLE
Fix deprecation warning in `Query.get_or_404()` for SQLAlchemy 2.x

### DIFF
--- a/src/flask_sqlalchemy/query.py
+++ b/src/flask_sqlalchemy/query.py
@@ -27,7 +27,8 @@ class Query(sa_orm.Query):  # type: ignore[type-arg]
         :param ident: The primary key to query.
         :param description: A custom message to show on the error page.
         """
-        rv = self.get(ident)
+        mapper = self._only_full_mapper_zero("get")
+        rv = self.session.get(mapper.class_, ident)
 
         if rv is None:
             abort(404, description=description)

--- a/src/flask_sqlalchemy/query.py
+++ b/src/flask_sqlalchemy/query.py
@@ -27,8 +27,9 @@ class Query(sa_orm.Query):  # type: ignore[type-arg]
         :param ident: The primary key to query.
         :param description: A custom message to show on the error page.
         """
-        mapper = self._only_full_mapper_zero("get")
-        rv = self.session.get(mapper.class_, ident)
+        model = (self.column_descriptions[0].get("entity")
+            or self.column_descriptions[0]["type"])
+        rv = self.session.get(model, ident)
 
         if rv is None:
             abort(404, description=description)


### PR DESCRIPTION
### **Description**

This pull request updates `Query.get_or_404()` to remove the use of the deprecated `Query.get()` method, which triggers a `LegacyAPIWarning` under SQLAlchemy 2.x.

The change aligns `get_or_404()` with the SQLAlchemy 2.x API by using the session’s `get()` method instead. This preserves existing behavior while ensuring forward compatibility and eliminating the deprecation warning.

fixes #1404

### **Additional Notes**

* No behavioral changes are introduced beyond internal API alignment.
* `first_or_404()` and `one_or_404()` are unaffected, as they do not use deprecated methods.