### PR TITLE
tests: dispose engines in app fixture cleanup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,11 +15,21 @@ from flask_sqlalchemy.model import Model
 
 
 @pytest.fixture
-def app(request: pytest.FixtureRequest, tmp_path: Path) -> Flask:
+def app(request: pytest.FixtureRequest, tmp_path: Path) -> t.Generator[Flask]:
     app = Flask(request.module.__name__, instance_path=str(tmp_path / "instance"))
     app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
     app.config["SQLALCHEMY_RECORD_QUERIES"] = False
-    return app
+    yield app
+
+    if app.extensions:
+        db = app.extensions["sqlalchemy"]
+        # Duplicate SQLAlchemy.engines logic to avoid errors when the app
+        # is not initialized properly.
+        if app in db._app_engines:
+            engines = db._app_engines[app]
+            if engines:
+                for engine in engines.values():
+                    engine.dispose()
 
 
 @pytest.fixture

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -156,6 +156,10 @@ def test_reflect(app: Flask) -> None:
     db.Table("post", sa.Column("id", sa.Integer, primary_key=True), bind_key="post")
     db.create_all()
 
+    # Dispose engines to close connections and avoid warning
+    for engine in db.engines.values():
+        engine.dispose()
+
     del app.extensions["sqlalchemy"]
     db = SQLAlchemy(app)
     assert not db.metadata.tables


### PR DESCRIPTION
The problem described in #1379 is caused by [a change to Python 3.13](https://docs.python.org/3/whatsnew/3.13.html#sqlite3) introduced in https://github.com/python/cpython/issues/105539. Calling [`engine.dispose()`](https://docs.sqlalchemy.org/en/20/core/connections.html#engine-disposal) makes SQLAlchemy close all connections from the pool used by engine.

This PR fixes tests by adding cleanup to the `app` fixture. Honestly, I don't know if this is only a problem with tests or if it can be somehow reproduced in a real use case.

fixes #1379
closes #1380

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
