### PR TITLE
[Bug] Fix pool instance in bind config raising exception

### DIFF
--- a/src/flask_sqlalchemy/extension.py
+++ b/src/flask_sqlalchemy/extension.py
@@ -371,7 +371,8 @@ class SQLAlchemy:
         for key, options in engine_options.items():
             self._make_metadata(key)
             options.setdefault("echo", echo)
-            options.setdefault("echo_pool", echo)
+            if "pool" not in options:
+                options.setdefault("echo_pool", echo)
             self._apply_driver_defaults(options, app)
             engines[key] = self._make_engine(key, options, app)
 
@@ -610,7 +611,8 @@ class SQLAlchemy:
 
         if url.drivername in {"sqlite", "sqlite+pysqlite"}:
             if url.database is None or url.database in {"", ":memory:"}:
-                options["poolclass"] = sa.pool.StaticPool
+                if "pool" not in options:
+                    options["poolclass"] = sa.pool.StaticPool
 
                 if "connect_args" not in options:
                     options["connect_args"] = {}

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -110,6 +110,16 @@ def test_sqlite_driver_level_uri(app: Flask, model_class: t.Any) -> None:
     assert os.path.exists(db_path[5:])
 
 
+@pytest.mark.usefixtures("app_ctx")
+def test_bind_with_pool_instance(app: Flask, model_class: t.Any) -> None:
+    import sqlite3
+
+    pool = sa.pool.StaticPool(creator=lambda: sqlite3.connect(":memory:"))
+    app.config["SQLALCHEMY_BINDS"] = {"a": {"url": "sqlite://", "pool": pool}}
+    db = SQLAlchemy(app, model_class=model_class)
+    assert db.engines["a"].pool is pool
+
+
 @unittest.mock.patch.object(SQLAlchemy, "_make_engine", autospec=True)
 def test_sqlite_memory_defaults(
     make_engine: unittest.mock.Mock, app: Flask, model_class: t.Any


### PR DESCRIPTION
Does not set `echo_pool` if a `pool` is passed via the bind config. See attached issue for relevant stack traces and bug description.

fixes #1421 