### PR TITLE
bug fix select pagination for multi-column results

### DIFF
--- a/src/flask_sqlalchemy/pagination.py
+++ b/src/flask_sqlalchemy/pagination.py
@@ -336,7 +336,7 @@ class SelectPagination(Pagination):
         select = self._query_args["select"]
         select = select.limit(self.per_page).offset(self._query_offset)
         session = self._query_args["session"]
-        return list(session.execute(select).unique().scalars())
+        return list(session.execute(select).unique().all())
 
     def _query_count(self) -> int:
         select = self._query_args["select"]


### PR DESCRIPTION
Return full result rows from SelectPagination instead of scalar values so paginated select queries preserve all selected columns.

fix #1423 

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
