### PR TITLE
AI junk

### DIFF
--- a/src/flask_sqlalchemy/extension.py
+++ b/src/flask_sqlalchemy/extension.py
@@ -609,7 +609,11 @@ class SQLAlchemy:
         url = sa.engine.make_url(options["url"])
 
         if url.drivername in {"sqlite", "sqlite+pysqlite"}:
-            if url.database is None or url.database in {"", ":memory:"}:
+            if (
+                url.database is None
+                or url.database in {"", ":memory:"}
+                or (url.database == "file::memory:" and url.query.get("uri"))
+            ):
                 options["poolclass"] = sa.pool.StaticPool
 
                 if "connect_args" not in options:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -110,6 +110,15 @@ def test_sqlite_driver_level_uri(app: Flask, model_class: t.Any) -> None:
     assert os.path.exists(db_path[5:])
 
 
+@pytest.mark.usefixtures("app_ctx")
+def test_sqlite_memory_uri(app: Flask, model_class: t.Any) -> None:
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///file::memory:?uri=true"
+    db = SQLAlchemy(app, model_class=model_class)
+    db.create_all()
+    assert isinstance(db.engine.pool, sa.pool.StaticPool)
+    assert not os.path.exists(os.path.join(app.instance_path, ":memory:"))
+
+
 @unittest.mock.patch.object(SQLAlchemy, "_make_engine", autospec=True)
 def test_sqlite_memory_defaults(
     make_engine: unittest.mock.Mock, app: Flask, model_class: t.Any


### PR DESCRIPTION
Fixes #1314

## Summary
When using a SQLite URI for an in-memory database like `sqlite:///file::memory:?uri=true`, Flask-SQLAlchemy was incorrectly treating it as a file-based database and creating a file on disk. This was due to the logic in `_apply_driver_defaults` not recognizing this specific URI format as an in-memory database. The fix is to update the condition that checks for in-memory SQLite databases to also include the case where `uri=true` is used with `file::memory:`. A regression test is added to ensure that no file is created on disk for this URI format and that the correct in-memory database settings (like `StaticPool`) are applied.

## Validation
Tests passing after 1 attempt(s).

```
tests/test_model_name.py ............................................... [ 57%]
.....................................                                    [ 65%]
tests/test_pagination.py ............................................... [ 75%]
..............................                                           [ 82%]
tests/test_record_queries.py .                                           [ 82%]
tests/test_session.py ..............................                     [ 89%]
tests/test_table_bind.py ....................                            [ 93%]
tests/test_track_modifications.py .....                                  [ 94%]
tests/test_view_query.py .........................                       [100%]
======================== 460 passed, 2 skipped in 4.43s ========================
```
