### PR TITLE
AI junk

### DIFF
--- a/src/flask_sqlalchemy/record_queries.py
+++ b/src/flask_sqlalchemy/record_queries.py
@@ -65,6 +65,7 @@ class _QueryInfo:
     start_time: float
     end_time: float
     location: str
+    bind_key: str | None
 
     @property
     def duration(self) -> float:
@@ -90,6 +91,14 @@ def _record_end(context: sa.engine.ExecutionContext, **kwargs: t.Any) -> None:
     if "_sqlalchemy_queries" not in g:
         g._sqlalchemy_queries = []
 
+    db = current_app.extensions["sqlalchemy"]
+    bind_key = None
+
+    for key, engine in db.engines.items():
+        if engine is context.engine:
+            bind_key = key
+            break
+
     import_top = current_app.import_name.partition(".")[0]
     import_dot = f"{import_top}."
     frame = inspect.currentframe()
@@ -113,5 +122,6 @@ def _record_end(context: sa.engine.ExecutionContext, **kwargs: t.Any) -> None:
             start_time=context._fsa_start_time,  # type: ignore[attr-defined]
             end_time=perf_counter(),
             location=location,
+            bind_key=bind_key,
         )
     )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -8,8 +8,10 @@ import pytest
 import sqlalchemy as sa
 import sqlalchemy.pool
 from flask import Flask
+from flask import g
 
 from flask_sqlalchemy import SQLAlchemy
+from flask_sqlalchemy.record_queries import get_recorded_queries
 
 
 def test_default_engine(app: Flask, db: SQLAlchemy) -> None:
@@ -129,3 +131,28 @@ def test_mysql_defaults(
     options = make_engine.call_args[0][2]
     assert options["pool_recycle"] == 7200
     assert options["url"].query["charset"] == "utf8mb4"
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_record_query_bind(app: Flask, model_class: t.Any) -> None:
+    app.config["SQLALCHEMY_RECORD_QUERIES"] = True
+    app.config["SQLALCHEMY_BINDS"] = {"a": "sqlite://"}
+    db = SQLAlchemy(app, model_class=model_class)
+
+    class Post(db.Model):
+        __bind_key__ = "a"
+        id = sa.Column(sa.Integer, primary_key=True)
+
+    db.create_all()
+
+    if hasattr(g, "_queries"):
+        g._queries.clear()
+
+    db.session.add(Post())
+    db.session.commit()
+    queries = get_recorded_queries()
+    insert_queries = [
+        q for q in queries if q.statement.strip().upper().startswith("INSERT")
+    ]
+    assert len(insert_queries) == 1
+    assert insert_queries[0].bind_key == "a"


### PR DESCRIPTION
Fixes #1402

## Summary
The `_QueryInfo` dataclass and the `_record_end` function in `record_queries.py` were missing the logic to handle `bind_key`. I've updated the dataclass to include the `bind_key` attribute and modified `_record_end` to determine and record the `bind_key` for each query. A regression test is also added to `tests/test_engine.py` to verify that the `bind_key` is correctly recorded.

## Validation
Tests passing after 4 attempt(s).

```
tests/test_model_name.py ............................................... [ 57%]
.....................................                                    [ 65%]
tests/test_pagination.py ............................................... [ 75%]
..............................                                           [ 82%]
tests/test_record_queries.py .                                           [ 82%]
tests/test_session.py ..............................                     [ 89%]
tests/test_table_bind.py ....................                            [ 93%]
tests/test_track_modifications.py .....                                  [ 94%]
tests/test_view_query.py .........................                       [100%]
======================== 460 passed, 2 skipped in 3.97s ========================
```
